### PR TITLE
fix: Bump Docker Node image from 22 to 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - compile the React application
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bumps the Dockerfile builder stage from `node:22-alpine` to `node:24-alpine`
- Matches the Node 24 version already used in CI (`release.yml`)
- Reduces likelihood of QEMU arm64 emulation crashes during multi-arch Docker builds