### PR TITLE
feat: Add CI workflow for pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check Types
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a new `ci.yml` GitHub Actions workflow that runs on all PRs targeting `main`
- Runs `npm run typecheck` and `npm run build` on the self-hosted runner
- Catches type and build failures before merge

## Follow-up: Enable branch protection
After merging, configure branch protection on `main` to require the `check` job to pass:

```bash
gh api repos/RunnymedeRobotics1310/RavenEye/branches/main/protection -X PUT \
  -F "required_status_checks[strict]=true" \
  -F "required_status_checks[checks][][context]=check" \
  -F "enforce_admins=false" \
  -F "required_pull_request_reviews=null" \
  -F "restrictions=null"
```

Or configure via GitHub Settings > Branches > Add branch protection rule.