### PR TITLE
feat: field map calibration stage 1

### DIFF
--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -3346,3 +3346,84 @@ a.kiosk-brand {
     overflow-x: auto;
 }
 
+.field-calibration-corners {
+    width: 100%;
+    margin: 0.5rem 0 0.75rem;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.field-calibration-corners th,
+.field-calibration-corners td {
+    padding: 0.35rem 0.6rem;
+    border-bottom: 1px solid var(--color-border);
+    text-align: left;
+    vertical-align: middle;
+}
+
+.field-calibration-corners thead th {
+    background: var(--color-bg-tertiary);
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.field-calibration-corners .corner-status-cell {
+    width: 1.75rem;
+    text-align: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+.field-calibration-corners .corner-coord-cell {
+    width: 6rem;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+}
+
+.field-calibration-corners .corner-hint {
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+}
+
+.field-calibration-corners .corner-done {
+    opacity: 0.7;
+}
+
+.field-calibration-corners .corner-done .corner-status-cell {
+    color: var(--color-success);
+}
+
+.field-calibration-corners .corner-active {
+    background: var(--color-accent-light);
+    outline: 2px solid var(--color-accent);
+}
+
+.field-calibration-corners .corner-active .corner-status-cell {
+    color: var(--color-accent);
+}
+
+.corner-badge {
+    display: inline-block;
+    min-width: 1.75rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.35rem;
+    font-weight: 700;
+    text-align: center;
+    border: 2px solid transparent;
+}
+
+.corner-badge-blue {
+    background: var(--alliance-blue-bg);
+    color: var(--alliance-blue);
+    border-color: var(--alliance-blue);
+}
+
+.corner-badge-red {
+    background: var(--alliance-red-bg);
+    color: var(--alliance-red);
+    border-color: var(--alliance-red);
+}
+

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -3236,3 +3236,113 @@ a.kiosk-brand {
     padding: 0.1rem 0.3rem;
 }
 
+/*
+ *
+ * FIELD MAP CALIBRATION
+ *
+ */
+
+/* The SVG overlay pins to the same rect as the field image. The container's
+   aspect-ratio (set inline from the current field dimensions) keeps the image
+   undistorted so normalized SVG coords land where the user clicked. */
+.field-map {
+    position: relative;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    background: var(--color-bg-tertiary);
+    border: 1px solid var(--color-border);
+    user-select: none;
+}
+
+.field-map img,
+.field-map svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.field-map svg {
+    overflow: visible;
+    touch-action: manipulation;
+}
+
+.field-grid-line {
+    stroke: var(--field-grid);
+    stroke-width: 1;
+    fill: none;
+}
+
+.field-axis-x {
+    stroke: var(--field-axis-x);
+    stroke-width: 3;
+    fill: none;
+}
+
+.field-axis-y {
+    stroke: var(--field-axis-y);
+    stroke-width: 1.5;
+    fill: none;
+}
+
+.field-origin-marker {
+    fill: var(--field-axis-x);
+    stroke: #ffffff;
+    stroke-width: 0.002;
+}
+
+.field-origin-label {
+    fill: var(--field-axis-x);
+    stroke: #ffffff;
+    stroke-width: 0.0015;
+}
+
+.robot-body-shape {
+    fill: var(--robot-body);
+    fill-opacity: 0.4;
+    stroke: var(--robot-body);
+    stroke-width: 2;
+}
+
+.robot-front-shape {
+    fill: var(--robot-front);
+    fill-opacity: 0.9;
+    stroke: var(--robot-body);
+    stroke-width: 1;
+}
+
+.field-calibration-page .form-field {
+    margin-bottom: 0.75rem;
+}
+
+.field-calibration-page .dimensions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem 1rem;
+}
+
+.field-calibration-phase {
+    font-weight: 600;
+    color: var(--color-accent);
+    margin: 0.25rem 0 0.5rem;
+}
+
+.field-calibration-error {
+    color: var(--color-error);
+    font-weight: 600;
+    margin: 0.5rem 0;
+}
+
+.field-calibration-verify {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    background: var(--color-bg-tertiary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    margin-top: 0.5rem;
+    white-space: pre;
+    overflow-x: auto;
+}
+

--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -82,6 +82,16 @@
 
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
     --shadow-md: 0 3px 10px rgba(0, 0, 0, 0.12);
+
+    /* Field-map calibration overlay palette (Paul Tol "Bright" — colour-blind
+       safe). Dual-encoded in markup: X axis thicker than Y, robot front is a
+       triangle, corners carry A/B/C/D letter labels. */
+    --field-grid: rgba(0, 0, 0, 0.25);
+    --field-axis-x: #0077BB;
+    --field-axis-y: #EE7733;
+    --field-corner: #CC3311;
+    --robot-body: #009988;
+    --robot-front: #EEDD00;
 }
 
 /* Dark mode */
@@ -143,5 +153,12 @@
 
         --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
         --shadow-md: 0 3px 10px rgba(0, 0, 0, 0.4);
+
+        --field-grid: rgba(255, 255, 255, 0.25);
+        --field-axis-x: #33BBEE;
+        --field-axis-y: #EE7733;
+        --field-corner: #EE3377;
+        --robot-body: #44BB99;
+        --robot-front: #EEDD00;
     }
 }

--- a/app/common/AdminMenu.tsx
+++ b/app/common/AdminMenu.tsx
@@ -83,6 +83,14 @@ const AdminMenu = () => {
               </NavLink>
             </li>
             <li>
+              <NavLink
+                to="/admin/field-map-calibration"
+                onClick={handleLinkClick}
+              >
+                Field Map Calibration
+              </NavLink>
+            </li>
+            <li>
               <NavLink to="/admin/design-system" onClick={handleLinkClick}>
                 Design System
               </NavLink>

--- a/app/common/field/fieldConstants.ts
+++ b/app/common/field/fieldConstants.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-year FRC field playing-surface dimensions in metres.
+ *
+ * These are user-overridable defaults: the calibration page pre-fills the
+ * form from this table but accepts any value the user types. Add a new year
+ * by dropping an entry in here — no other code changes required.
+ *
+ * Source: 2026 REBUILT Game Manual §5.2 — 651.2 in × 317.7 in ≈ 16.54 × 8.07 m.
+ */
+export const FIELD_DIMENSIONS_BY_YEAR: Record<
+  number,
+  { lengthM: number; widthM: number }
+> = {
+  2026: { lengthM: 16.54, widthM: 8.07 },
+};
+
+/**
+ * Default robot footprint in metres. Most FRC robots fit inside the 30" × 30"
+ * frame-perimeter limit; 0.84 m ≈ 33" accounts for bumpers. The calibration
+ * page pre-fills these but the user can override per-season.
+ */
+export const DEFAULT_ROBOT_DIMENSIONS_M = {
+  lengthM: 0.84,
+  widthM: 0.84,
+};

--- a/app/common/field/homography.ts
+++ b/app/common/field/homography.ts
@@ -1,0 +1,232 @@
+/**
+ * 2D perspective-transform math for field-map calibration.
+ *
+ * A homography is a 3×3 matrix that maps 2D points from one plane to another
+ * under perspective. We store it row-major as a 9-element array:
+ *
+ *     [ h0 h1 h2 ]
+ *     [ h3 h4 h5 ]
+ *     [ h6 h7 h8 ]
+ *
+ * `h8` is normalized to 1, leaving 8 degrees of freedom — exactly what four
+ * point correspondences can constrain.
+ *
+ * Everything in this module is pure: no React, no DOM, no external deps.
+ *
+ * ---------- Hand-traced sanity checks ----------
+ *
+ * Identity square → identity square:
+ *   src = [(0,0),(1,0),(1,1),(0,1)]
+ *   dst = [(0,0),(1,0),(1,1),(0,1)]
+ *   → H ≈ [1,0,0, 0,1,0, 0,0,1], applyHomography(H, (0.5, 0.5)) = (0.5, 0.5)
+ *
+ * Unit-square field to normalized image:
+ *   src = [(0,0),(1,0),(1,1),(0,1)] (field metres, 1×1)
+ *   dst = [(0.1,0.1),(0.9,0.1),(0.9,0.9),(0.1,0.9)] (inset 10% on each side)
+ *   → (0.5, 0.5) field maps to (0.5, 0.5) image by symmetry.
+ *
+ * Round-trip property:
+ *   For a well-formed calibration, imageNormalizedToField ∘ fieldToImageNormalized
+ *   is the identity to within ~1e-9.
+ */
+
+export type Point = { x: number; y: number };
+
+/** Row-major 3×3 matrix. Length is always 9. h[8] is normalized to 1. */
+export type Homography = number[];
+
+/**
+ * Compute the homography mapping each `src[i]` to the corresponding `dst[i]`.
+ * Both arrays must have exactly 4 points.
+ *
+ * Throws `Error` if the linear system is singular (degenerate input). Callers
+ * should gate on `isCalibrationWellFormed` first.
+ */
+export function computeHomography(src: Point[], dst: Point[]): Homography {
+  if (src.length !== 4 || dst.length !== 4) {
+    throw new Error("computeHomography requires exactly 4 source and 4 destination points");
+  }
+
+  // Build the 8×9 system. For each correspondence (x, y) → (u, v) we write two
+  // rows of the linear system A * h = 0 (direct linear transform, DLT):
+  //
+  //   [ x  y  1  0  0  0  -u*x  -u*y  -u ] * h = 0
+  //   [ 0  0  0  x  y  1  -v*x  -v*y  -v ] * h = 0
+  //
+  // We pin h8 = 1, so we move the last column to the RHS and solve an 8×8
+  // linear system for h0..h7.
+  const a: number[][] = [];
+  const b: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    const { x, y } = src[i]!;
+    const { x: u, y: v } = dst[i]!;
+    a.push([x, y, 1, 0, 0, 0, -u * x, -u * y]);
+    b.push(u);
+    a.push([0, 0, 0, x, y, 1, -v * x, -v * y]);
+    b.push(v);
+  }
+
+  const h = solveLinearSystem(a, b);
+  return [h[0]!, h[1]!, h[2]!, h[3]!, h[4]!, h[5]!, h[6]!, h[7]!, 1];
+}
+
+/** Apply a homography to a point. */
+export function applyHomography(h: Homography, p: Point): Point {
+  const x = p.x;
+  const y = p.y;
+  const w = h[6]! * x + h[7]! * y + h[8]!;
+  return {
+    x: (h[0]! * x + h[1]! * y + h[2]!) / w,
+    y: (h[3]! * x + h[4]! * y + h[5]!) / w,
+  };
+}
+
+/**
+ * Return a function mapping field metres → normalized image coords (0..1 each)
+ * for the given calibration. The field-corner mapping is fixed by the click
+ * order documented in the plan:
+ *
+ *   click 0 = (0,   0)    "Blue origin"
+ *   click 1 = (L,   0)    "Red origin"
+ *   click 2 = (L,   W)    "Red far"
+ *   click 3 = (0,   W)    "Blue far"
+ */
+export function fieldToImageNormalized(cal: CalibrationLike): (p: Point) => Point {
+  const src = fieldCorners(cal);
+  const dst = imageCorners(cal);
+  const h = computeHomography(src, dst);
+  return (p) => applyHomography(h, p);
+}
+
+/** Inverse of {@link fieldToImageNormalized}. */
+export function imageNormalizedToField(cal: CalibrationLike): (p: Point) => Point {
+  const src = imageCorners(cal);
+  const dst = fieldCorners(cal);
+  const h = computeHomography(src, dst);
+  return (p) => applyHomography(h, p);
+}
+
+export type CalibrationLike = {
+  fieldLengthM: number;
+  fieldWidthM: number;
+  corners: [Point, Point, Point, Point];
+};
+
+export type WellFormedResult =
+  | { ok: true }
+  | { ok: false; reason: "colinear" | "too-close" | "self-intersecting" };
+
+/**
+ * Returns `{ ok: true }` if the four normalized image corners describe a
+ * well-formed, non-degenerate, convex quadrilateral in click order.
+ *
+ * Rejection reasons:
+ *   - `too-close`: two points are within `minEdgeNormalized` of each other.
+ *   - `colinear`:  the points have no turn (cross products are zero).
+ *   - `self-intersecting`: the click order traces a bowtie (edge sign flips).
+ */
+export function isCalibrationWellFormed(
+  corners: Point[],
+  minEdgeNormalized = 0.01,
+): WellFormedResult {
+  if (corners.length !== 4) return { ok: false, reason: "too-close" };
+
+  for (let i = 0; i < 4; i++) {
+    for (let j = i + 1; j < 4; j++) {
+      const dx = corners[j]!.x - corners[i]!.x;
+      const dy = corners[j]!.y - corners[i]!.y;
+      if (Math.hypot(dx, dy) < minEdgeNormalized) {
+        return { ok: false, reason: "too-close" };
+      }
+    }
+  }
+
+  // Convexity: the cross product of each pair of consecutive edges must be
+  // non-zero and all share the same sign. Zero → colinear; mixed signs → the
+  // quad self-intersects (bowtie).
+  let sign = 0;
+  for (let i = 0; i < 4; i++) {
+    const a = corners[i]!;
+    const b = corners[(i + 1) % 4]!;
+    const c = corners[(i + 2) % 4]!;
+    const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
+    if (Math.abs(cross) < 1e-9) return { ok: false, reason: "colinear" };
+    const s = cross > 0 ? 1 : -1;
+    if (sign === 0) sign = s;
+    else if (s !== sign) return { ok: false, reason: "self-intersecting" };
+  }
+  return { ok: true };
+}
+
+// ---------- internals ----------
+
+function fieldCorners(cal: CalibrationLike): Point[] {
+  const L = cal.fieldLengthM;
+  const W = cal.fieldWidthM;
+  return [
+    { x: 0, y: 0 },
+    { x: L, y: 0 },
+    { x: L, y: W },
+    { x: 0, y: W },
+  ];
+}
+
+function imageCorners(cal: CalibrationLike): Point[] {
+  return cal.corners.map((c) => ({ x: c.x, y: c.y }));
+}
+
+/**
+ * Solve `A * x = b` for a square `A` via Gaussian elimination with partial
+ * pivoting. `A` is n×n and `b` is length n. Returns the length-n solution.
+ * Throws if the system is singular (pivot magnitude below 1e-12).
+ */
+function solveLinearSystem(aIn: number[][], bIn: number[]): number[] {
+  const n = aIn.length;
+  // Copy to avoid mutating caller arrays.
+  const a: number[][] = aIn.map((row) => row.slice());
+  const b: number[] = bIn.slice();
+
+  for (let k = 0; k < n; k++) {
+    // Partial pivoting: find the row with the largest |a[i][k]| for i >= k.
+    let maxRow = k;
+    let maxVal = Math.abs(a[k]![k]!);
+    for (let i = k + 1; i < n; i++) {
+      const v = Math.abs(a[i]![k]!);
+      if (v > maxVal) {
+        maxVal = v;
+        maxRow = i;
+      }
+    }
+    if (maxVal < 1e-12) {
+      throw new Error("solveLinearSystem: singular matrix");
+    }
+    if (maxRow !== k) {
+      const tmp = a[k]!;
+      a[k] = a[maxRow]!;
+      a[maxRow] = tmp;
+      const tb = b[k]!;
+      b[k] = b[maxRow]!;
+      b[maxRow] = tb;
+    }
+
+    // Eliminate below the pivot.
+    for (let i = k + 1; i < n; i++) {
+      const factor = a[i]![k]! / a[k]![k]!;
+      for (let j = k; j < n; j++) {
+        a[i]![j] = a[i]![j]! - factor * a[k]![j]!;
+      }
+      b[i] = b[i]! - factor * b[k]!;
+    }
+  }
+
+  // Back-substitution.
+  const x = new Array<number>(n).fill(0);
+  for (let i = n - 1; i >= 0; i--) {
+    let sum = b[i]!;
+    for (let j = i + 1; j < n; j++) {
+      sum -= a[i]![j]! * x[j]!;
+    }
+    x[i] = sum / a[i]![i]!;
+  }
+  return x;
+}

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -31,6 +31,7 @@ import type { PmvaReportResponse } from "~/types/PmvaReport.ts";
 import type { MatchStrategyPlan } from "~/types/MatchStrategyPlan.ts";
 import type { MatchStrategyDrawing } from "~/types/MatchStrategyDrawing.ts";
 import type { StrategyStroke } from "~/types/StrategyStroke.ts";
+import type { FieldCalibration } from "~/types/FieldCalibration.ts";
 
 /**
  * Sends a ping request to the API to check if the server is reachable.
@@ -1446,4 +1447,102 @@ export async function deleteStrategyDrawing(id: number): Promise<void> {
   if (!resp.ok && resp.status !== 204) {
     throw new Error("Failed to delete strategy drawing: " + resp.status);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Field Calibration
+// ---------------------------------------------------------------------------
+//
+// The backend stores corners as eight flat columns (corner0_x..corner3_y).
+// The frontend uses a nested `corners: [{x,y}, ...]` tuple, which is easier
+// to iterate and to feed directly into the homography math. These helpers do
+// the translation at the API boundary.
+
+interface WireFieldCalibration {
+  id?: number | null;
+  year: number;
+  fieldLengthM: number;
+  fieldWidthM: number;
+  robotLengthM: number;
+  robotWidthM: number;
+  corner0X: number;
+  corner0Y: number;
+  corner1X: number;
+  corner1Y: number;
+  corner2X: number;
+  corner2Y: number;
+  corner3X: number;
+  corner3Y: number;
+  updatedAt?: string | null;
+  updatedByUserId?: number | null;
+}
+
+function wireToFieldCalibration(w: WireFieldCalibration): FieldCalibration {
+  return {
+    id: w.id,
+    year: w.year,
+    fieldLengthM: w.fieldLengthM,
+    fieldWidthM: w.fieldWidthM,
+    robotLengthM: w.robotLengthM,
+    robotWidthM: w.robotWidthM,
+    corners: [
+      { x: w.corner0X, y: w.corner0Y },
+      { x: w.corner1X, y: w.corner1Y },
+      { x: w.corner2X, y: w.corner2Y },
+      { x: w.corner3X, y: w.corner3Y },
+    ],
+    updatedAt: w.updatedAt,
+    updatedByUserId: w.updatedByUserId,
+  };
+}
+
+function fieldCalibrationToWire(c: FieldCalibration): WireFieldCalibration {
+  return {
+    year: c.year,
+    fieldLengthM: c.fieldLengthM,
+    fieldWidthM: c.fieldWidthM,
+    robotLengthM: c.robotLengthM,
+    robotWidthM: c.robotWidthM,
+    corner0X: c.corners[0].x,
+    corner0Y: c.corners[0].y,
+    corner1X: c.corners[1].x,
+    corner1Y: c.corners[1].y,
+    corner2X: c.corners[2].x,
+    corner2Y: c.corners[2].y,
+    corner3X: c.corners[3].x,
+    corner3Y: c.corners[3].y,
+  };
+}
+
+/**
+ * Intentional divergence from the default rb.ts idiom: returns `null` on 404
+ * rather than throwing. The first time an admin opens the calibration page
+ * for a given year there is legitimately no record — that must be a normal
+ * empty state, not an error path. Any other non-OK response still throws.
+ */
+export async function getFieldCalibration(
+  year: number,
+): Promise<FieldCalibration | null> {
+  const resp = await rbfetch(`/api/field-calibration/${year}`, {});
+  if (resp.ok) {
+    const wire = (await resp.json()) as unknown as WireFieldCalibration;
+    return wireToFieldCalibration(wire);
+  }
+  if (resp.status === 404) return null;
+  throw new Error("Failure fetching field calibration for year " + year);
+}
+
+export async function saveFieldCalibration(
+  year: number,
+  cal: FieldCalibration,
+): Promise<FieldCalibration> {
+  const resp = await rbfetch(`/api/field-calibration/${year}`, {
+    method: "PUT",
+    body: JSON.stringify(fieldCalibrationToWire(cal)),
+  });
+  if (!resp.ok) {
+    throw new Error("Failure saving field calibration: " + resp.status);
+  }
+  const wire = (await resp.json()) as unknown as WireFieldCalibration;
+  return wireToFieldCalibration(wire);
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -53,6 +53,10 @@ export default [
   route("admin/tournament-streams", "./routes/admin/tournament-streams-page.tsx"),
   route("admin/match-videos", "./routes/admin/match-videos-page.tsx"),
   route("admin/match-videos/:tournamentId", "./routes/admin/match-videos-detail-page.tsx"),
+  route(
+    "admin/field-map-calibration",
+    "./routes/admin/field-map-calibration/calibration-page.tsx",
+  ),
   route("profile", "./routes/profile/profile-page.tsx"),
   route("report", "./routes/report/report-home-page.tsx"),
   route("report/schedule", "./routes/report/team-schedule-page.tsx"),

--- a/app/routes/admin/field-map-calibration/FieldCalibrationOverlay.tsx
+++ b/app/routes/admin/field-map-calibration/FieldCalibrationOverlay.tsx
@@ -1,0 +1,277 @@
+import { useMemo, type MouseEvent } from "react";
+import {
+  type Point,
+  applyHomography,
+  computeHomography,
+} from "~/common/field/homography.ts";
+
+export type OverlayPhase =
+  | "idle"
+  | "picking-corner-0"
+  | "picking-corner-1"
+  | "picking-corner-2"
+  | "picking-corner-3"
+  | "ready";
+
+export type FieldPose = { xm: number; ym: number; headingDeg: number };
+
+type Props = {
+  imageUrl: string;
+  fieldL: number;
+  fieldW: number;
+  robotL: number;
+  robotW: number;
+  /** Picked image corners (normalized 0..1). 0 to 4 entries. */
+  corners: Point[];
+  phase: OverlayPhase;
+  /** Pose to draw in the ready state. Omitted → no robot rendered. */
+  pose?: FieldPose;
+  /** Click-through: called with normalized image coords in [0, 1]. */
+  onCornerClick?: (p: Point) => void;
+};
+
+const CORNER_LABELS = ["A", "B", "C", "D"] as const;
+
+/**
+ * Field image + normalized-coord SVG overlay. The SVG sits directly on top of
+ * the `<img>` at the same rendered rect; its `viewBox="0 0 1 1"` with
+ * `preserveAspectRatio="none"` means each SVG coordinate is a normalized 0..1
+ * image coord — exactly what clicks produce, and exactly what the backend
+ * stores.
+ */
+export default function FieldCalibrationOverlay({
+  imageUrl,
+  fieldL,
+  fieldW,
+  robotL,
+  robotW,
+  corners,
+  phase,
+  pose,
+  onCornerClick,
+}: Props) {
+  const isPicking = phase.startsWith("picking-") || phase === "idle";
+  const isReady = phase === "ready" && corners.length === 4;
+
+  // Compute the field→image homography once per calibration snapshot. When
+  // picking, `corners` grows click by click so the homography isn't valid
+  // until we're in `ready`.
+  const fieldToImage = useMemo(() => {
+    if (!isReady) return null;
+    const src: Point[] = [
+      { x: 0, y: 0 },
+      { x: fieldL, y: 0 },
+      { x: fieldL, y: fieldW },
+      { x: 0, y: fieldW },
+    ];
+    const h = computeHomography(src, corners);
+    return (p: Point) => applyHomography(h, p);
+  }, [isReady, fieldL, fieldW, corners]);
+
+  const handleClick = (e: MouseEvent<SVGSVGElement>) => {
+    if (!onCornerClick || !isPicking) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width;
+    const y = (e.clientY - rect.top) / rect.height;
+    onCornerClick({ x, y });
+  };
+
+  return (
+    <div className="field-map" style={{ aspectRatio: `${fieldL} / ${fieldW}` }}>
+      <img src={imageUrl} alt="FRC field" draggable={false} />
+      <svg
+        viewBox="0 0 1 1"
+        preserveAspectRatio="none"
+        onClick={handleClick}
+        style={{ cursor: isPicking && onCornerClick ? "crosshair" : "default" }}
+      >
+        {/* Picked corners — shown during calibration and still visible in
+            ready so the user can see what they clicked. */}
+        {corners.map((c, i) => (
+          <g key={`corner-${i}`}>
+            <circle
+              cx={c.x}
+              cy={c.y}
+              r="0.008"
+              fill="var(--field-corner)"
+              stroke="#ffffff"
+              strokeWidth="0.0015"
+            />
+            <text
+              x={c.x + 0.012}
+              y={c.y - 0.012}
+              fontSize="0.025"
+              fontWeight="700"
+              fill="var(--field-corner)"
+              stroke="#ffffff"
+              strokeWidth="0.0015"
+              paintOrder="stroke"
+            >
+              {CORNER_LABELS[i]}
+            </text>
+          </g>
+        ))}
+
+        {isReady && fieldToImage && (
+          <>
+            <GridAndAxes
+              fieldL={fieldL}
+              fieldW={fieldW}
+              fieldToImage={fieldToImage}
+            />
+            {pose && (
+              <Robot
+                pose={pose}
+                robotL={robotL}
+                robotW={robotW}
+                fieldToImage={fieldToImage}
+              />
+            )}
+          </>
+        )}
+      </svg>
+    </div>
+  );
+}
+
+function GridAndAxes({
+  fieldL,
+  fieldW,
+  fieldToImage,
+}: {
+  fieldL: number;
+  fieldW: number;
+  fieldToImage: (p: Point) => Point;
+}) {
+  // One-metre spaced lines across the whole field.
+  const xLines: number[] = [];
+  for (let x = 0; x <= fieldL + 1e-9; x += 1) xLines.push(Math.min(x, fieldL));
+  const yLines: number[] = [];
+  for (let y = 0; y <= fieldW + 1e-9; y += 1) yLines.push(Math.min(y, fieldW));
+
+  const line = (a: Point, b: Point, key: string, cls: string) => {
+    const ai = fieldToImage(a);
+    const bi = fieldToImage(b);
+    return (
+      <line
+        key={key}
+        x1={ai.x}
+        y1={ai.y}
+        x2={bi.x}
+        y2={bi.y}
+        className={cls}
+        vectorEffect="non-scaling-stroke"
+      />
+    );
+  };
+
+  const origin = fieldToImage({ x: 0, y: 0 });
+  const xAxisEnd = fieldToImage({ x: fieldL, y: 0 });
+  const yAxisEnd = fieldToImage({ x: 0, y: fieldW });
+
+  return (
+    <g className="field-overlay">
+      {xLines.map((x, i) =>
+        x > 0 && x < fieldL
+          ? line({ x, y: 0 }, { x, y: fieldW }, `xg-${i}`, "field-grid-line")
+          : null,
+      )}
+      {yLines.map((y, i) =>
+        y > 0 && y < fieldW
+          ? line({ x: 0, y }, { x: fieldL, y }, `yg-${i}`, "field-grid-line")
+          : null,
+      )}
+      {/* X axis — thicker than Y for dual-encoded identification. */}
+      <line
+        x1={origin.x}
+        y1={origin.y}
+        x2={xAxisEnd.x}
+        y2={xAxisEnd.y}
+        className="field-axis-x"
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        x1={origin.x}
+        y1={origin.y}
+        x2={yAxisEnd.x}
+        y2={yAxisEnd.y}
+        className="field-axis-y"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle
+        cx={origin.x}
+        cy={origin.y}
+        r="0.007"
+        className="field-origin-marker"
+      />
+      <text
+        x={origin.x + 0.012}
+        y={origin.y + 0.028}
+        fontSize="0.022"
+        fontWeight="700"
+        className="field-origin-label"
+        paintOrder="stroke"
+      >
+        0,0
+      </text>
+    </g>
+  );
+}
+
+function Robot({
+  pose,
+  robotL,
+  robotW,
+  fieldToImage,
+}: {
+  pose: FieldPose;
+  robotL: number;
+  robotW: number;
+  fieldToImage: (p: Point) => Point;
+}) {
+  const hl = robotL / 2;
+  const hw = robotW / 2;
+  const heading = (pose.headingDeg * Math.PI) / 180;
+  const cos = Math.cos(heading);
+  const sin = Math.sin(heading);
+
+  // Local-frame corners: CCW starting at rear-right. Heading 0 ⇒ +X is front.
+  const localBody: Point[] = [
+    { x: -hl, y: -hw },
+    { x: +hl, y: -hw },
+    { x: +hl, y: +hw },
+    { x: -hl, y: +hw },
+  ];
+
+  // Front-indicator triangle: base narrowed to ~40% of robot width centred on
+  // the front edge; apex ~20% of robot length inward.
+  const localFront: Point[] = [
+    { x: +hl, y: -hw * 0.4 },
+    { x: +hl, y: +hw * 0.4 },
+    { x: +hl - robotL * 0.2, y: 0 },
+  ];
+
+  const toImage = (local: Point) => {
+    const rx = cos * local.x - sin * local.y + pose.xm;
+    const ry = sin * local.x + cos * local.y + pose.ym;
+    return fieldToImage({ x: rx, y: ry });
+  };
+
+  const bodyPoints = localBody.map(toImage).map((p) => `${p.x},${p.y}`).join(" ");
+  const frontPoints = localFront.map(toImage).map((p) => `${p.x},${p.y}`).join(" ");
+
+  return (
+    <g className="field-robot">
+      <polygon
+        points={bodyPoints}
+        className="robot-body-shape"
+        vectorEffect="non-scaling-stroke"
+      />
+      <polygon
+        points={frontPoints}
+        className="robot-front-shape"
+        vectorEffect="non-scaling-stroke"
+      />
+    </g>
+  );
+}

--- a/app/routes/admin/field-map-calibration/calibration-page.tsx
+++ b/app/routes/admin/field-map-calibration/calibration-page.tsx
@@ -1,0 +1,387 @@
+import { useEffect, useMemo, useState } from "react";
+import RequireLogin from "~/common/auth/RequireLogin.tsx";
+import Spinner from "~/common/Spinner.tsx";
+import {
+  getFieldCalibration,
+  saveFieldCalibration,
+} from "~/common/storage/rb.ts";
+import { fieldImageForYear } from "~/common/strategy/fieldImage.ts";
+import {
+  DEFAULT_ROBOT_DIMENSIONS_M,
+  FIELD_DIMENSIONS_BY_YEAR,
+} from "~/common/field/fieldConstants.ts";
+import {
+  type Point,
+  fieldToImageNormalized,
+  imageNormalizedToField,
+  isCalibrationWellFormed,
+} from "~/common/field/homography.ts";
+import type { FieldCalibration } from "~/types/FieldCalibration.ts";
+import FieldCalibrationOverlay, {
+  type OverlayPhase,
+} from "./FieldCalibrationOverlay.tsx";
+
+const DEFAULT_YEAR = 2026;
+
+// Stage 1 renders a single fixed pose as a visual confirmation that the
+// homography is sane. Stage 2 replaces this with real telemetry playback.
+const STAGE_1_FIXED_POSE = { xm: 2.0, ym: 2.0, headingDeg: 0 };
+
+const PHASES_FOR_CLICK_COUNT: OverlayPhase[] = [
+  "picking-corner-0",
+  "picking-corner-1",
+  "picking-corner-2",
+  "picking-corner-3",
+  "ready",
+];
+
+function defaultDimensions(year: number) {
+  const dims = FIELD_DIMENSIONS_BY_YEAR[year];
+  return {
+    fieldLengthM: dims?.lengthM ?? 16.54,
+    fieldWidthM: dims?.widthM ?? 8.07,
+    robotLengthM: DEFAULT_ROBOT_DIMENSIONS_M.lengthM,
+    robotWidthM: DEFAULT_ROBOT_DIMENSIONS_M.widthM,
+  };
+}
+
+const CalibrationWorkArea = () => {
+  const [year, setYear] = useState<number>(DEFAULT_YEAR);
+  const [fieldLengthM, setFieldLengthM] = useState<number>(
+    defaultDimensions(DEFAULT_YEAR).fieldLengthM,
+  );
+  const [fieldWidthM, setFieldWidthM] = useState<number>(
+    defaultDimensions(DEFAULT_YEAR).fieldWidthM,
+  );
+  const [robotLengthM, setRobotLengthM] = useState<number>(
+    DEFAULT_ROBOT_DIMENSIONS_M.lengthM,
+  );
+  const [robotWidthM, setRobotWidthM] = useState<number>(
+    DEFAULT_ROBOT_DIMENSIONS_M.widthM,
+  );
+  const [corners, setCorners] = useState<Point[]>([]);
+  const [phase, setPhase] = useState<OverlayPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
+  const [verifyText, setVerifyText] = useState<string | null>(null);
+
+  // Load existing calibration (or defaults) whenever the year changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setVerifyText(null);
+    setSaveStatus(null);
+    getFieldCalibration(year)
+      .then((cal) => {
+        if (cancelled) return;
+        if (cal) {
+          setFieldLengthM(cal.fieldLengthM);
+          setFieldWidthM(cal.fieldWidthM);
+          setRobotLengthM(cal.robotLengthM);
+          setRobotWidthM(cal.robotWidthM);
+          setCorners(cal.corners.map((c) => ({ x: c.x, y: c.y })));
+          setPhase("ready");
+        } else {
+          const d = defaultDimensions(year);
+          setFieldLengthM(d.fieldLengthM);
+          setFieldWidthM(d.fieldWidthM);
+          setRobotLengthM(d.robotLengthM);
+          setRobotWidthM(d.robotWidthM);
+          setCorners([]);
+          setPhase("idle");
+        }
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(
+          "Could not load calibration: " +
+            (e instanceof Error ? e.message : String(e)),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [year]);
+
+  const startPicking = () => {
+    setCorners([]);
+    setPhase("picking-corner-0");
+    setError(null);
+    setVerifyText(null);
+  };
+
+  const handleCornerClick = (p: Point) => {
+    const next = [...corners, p];
+    if (next.length < 4) {
+      setCorners(next);
+      setPhase(PHASES_FOR_CLICK_COUNT[next.length]!);
+      return;
+    }
+    // Fourth click: validate the whole quad before committing.
+    const check = isCalibrationWellFormed(next);
+    if (!check.ok) {
+      setError(errorCopyFor(check.reason));
+      // Stay in picking-corner-3 with only 3 corners so the user can adjust.
+      setCorners(next.slice(0, 3));
+      setPhase("picking-corner-3");
+      return;
+    }
+    setCorners(next);
+    setPhase("ready");
+    setError(null);
+  };
+
+  const handleReset = () => {
+    setCorners([]);
+    setPhase("idle");
+    setError(null);
+    setVerifyText(null);
+    setSaveStatus(null);
+  };
+
+  const calibration: FieldCalibration | null = useMemo(() => {
+    if (phase !== "ready" || corners.length !== 4) return null;
+    return {
+      year,
+      fieldLengthM,
+      fieldWidthM,
+      robotLengthM,
+      robotWidthM,
+      corners: [corners[0]!, corners[1]!, corners[2]!, corners[3]!],
+    };
+  }, [
+    phase,
+    corners,
+    year,
+    fieldLengthM,
+    fieldWidthM,
+    robotLengthM,
+    robotWidthM,
+  ]);
+
+  const handleSave = async () => {
+    if (!calibration) return;
+    setSaving(true);
+    setError(null);
+    setSaveStatus(null);
+    try {
+      await saveFieldCalibration(year, calibration);
+      setSaveStatus("Saved.");
+    } catch (e: unknown) {
+      setError(
+        "Could not save: " + (e instanceof Error ? e.message : String(e)),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVerify = () => {
+    if (!calibration) return;
+    const toImage = fieldToImageNormalized(calibration);
+    const toField = imageNormalizedToField(calibration);
+    const testPoints: Point[] = [
+      { x: 0, y: 0 },
+      { x: fieldLengthM, y: 0 },
+      { x: fieldLengthM, y: fieldWidthM },
+      { x: 0, y: fieldWidthM },
+      { x: fieldLengthM / 2, y: fieldWidthM / 2 },
+    ];
+    const rows = testPoints.map((p) => {
+      const round = toField(toImage(p));
+      const deltaMm = Math.hypot(p.x - round.x, p.y - round.y) * 1000;
+      return `(${p.x.toFixed(2)}, ${p.y.toFixed(2)}) m → Δ ${deltaMm.toFixed(3)} mm`;
+    });
+    setVerifyText(rows.join("\n"));
+  };
+
+  if (loading) return <Spinner />;
+
+  const imageUrl = fieldImageForYear(year);
+
+  const phaseHint = (() => {
+    switch (phase) {
+      case "idle":
+        return "Press Start to begin clicking the four field corners.";
+      case "picking-corner-0":
+        return "Click the BLUE origin corner (field 0, 0).";
+      case "picking-corner-1":
+        return "Click the RED origin corner (field L, 0).";
+      case "picking-corner-2":
+        return "Click the RED far corner (field L, W).";
+      case "picking-corner-3":
+        return "Click the BLUE far corner (field 0, W).";
+      case "ready":
+        return "Calibration ready. A robot at (2, 2, 0°) is drawn as a visual sanity check.";
+    }
+  })();
+
+  return (
+    <section className="field-calibration-page">
+      <div className="form-field">
+        <label htmlFor="fmc-year">FRC season</label>
+        <input
+          id="fmc-year"
+          type="number"
+          min={2000}
+          max={2100}
+          value={year}
+          onChange={(e) => setYear(parseInt(e.target.value, 10) || year)}
+        />
+      </div>
+
+      <fieldset>
+        <legend>Field dimensions (m)</legend>
+        <div className="dimensions-grid">
+          <div className="form-field">
+            <label htmlFor="fmc-field-l">Length (L)</label>
+            <input
+              id="fmc-field-l"
+              type="number"
+              step="0.01"
+              min="1"
+              value={fieldLengthM}
+              onChange={(e) =>
+                setFieldLengthM(parseFloat(e.target.value) || fieldLengthM)
+              }
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="fmc-field-w">Width (W)</label>
+            <input
+              id="fmc-field-w"
+              type="number"
+              step="0.01"
+              min="1"
+              value={fieldWidthM}
+              onChange={(e) =>
+                setFieldWidthM(parseFloat(e.target.value) || fieldWidthM)
+              }
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Robot dimensions (m)</legend>
+        <div className="dimensions-grid">
+          <div className="form-field">
+            <label htmlFor="fmc-robot-l">Length</label>
+            <input
+              id="fmc-robot-l"
+              type="number"
+              step="0.01"
+              min="0.1"
+              value={robotLengthM}
+              onChange={(e) =>
+                setRobotLengthM(parseFloat(e.target.value) || robotLengthM)
+              }
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="fmc-robot-w">Width</label>
+            <input
+              id="fmc-robot-w"
+              type="number"
+              step="0.01"
+              min="0.1"
+              value={robotWidthM}
+              onChange={(e) =>
+                setRobotWidthM(parseFloat(e.target.value) || robotWidthM)
+              }
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Calibrate corners</legend>
+        <p className="field-calibration-phase">{phaseHint}</p>
+        <FieldCalibrationOverlay
+          imageUrl={imageUrl}
+          fieldL={fieldLengthM}
+          fieldW={fieldWidthM}
+          robotL={robotLengthM}
+          robotW={robotWidthM}
+          corners={corners}
+          phase={phase}
+          pose={phase === "ready" ? STAGE_1_FIXED_POSE : undefined}
+          onCornerClick={handleCornerClick}
+        />
+        {error && <p className="field-calibration-error">{error}</p>}
+        <div className="form-actions" style={{ marginTop: "0.75rem" }}>
+          {phase === "idle" || phase === "ready" ? (
+            <button type="button" onClick={startPicking}>
+              {phase === "ready" ? "Re-calibrate" : "Start"}
+            </button>
+          ) : (
+            <button type="button" onClick={handleReset} className="secondary">
+              Reset
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={phase !== "ready" || saving}
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={handleVerify}
+            disabled={phase !== "ready"}
+            className="secondary"
+          >
+            Verify transform
+          </button>
+        </div>
+        {saveStatus && (
+          <p style={{ color: "var(--color-success)", marginTop: "0.5rem" }}>
+            {saveStatus}
+          </p>
+        )}
+        {verifyText && (
+          <pre className="field-calibration-verify">{verifyText}</pre>
+        )}
+      </fieldset>
+    </section>
+  );
+};
+
+function errorCopyFor(
+  reason: "colinear" | "too-close" | "self-intersecting",
+): string {
+  switch (reason) {
+    case "too-close":
+      return "Two corners are nearly the same point. Click the four distinct field corners.";
+    case "colinear":
+      return "The four corners fall on a line. Click corners that enclose the field.";
+    case "self-intersecting":
+      return "The click order crosses itself. Follow the order: blue origin → red origin → red far → blue far.";
+  }
+}
+
+const FieldMapCalibrationPage = () => {
+  return (
+    <main>
+      <div className="page-header">
+        <h1>Field Map Calibration</h1>
+        <p>
+          Click the four field corners in the prescribed order to calibrate the
+          image-to-field coordinate transform used by telemetry overlays.
+        </p>
+      </div>
+      <RequireLogin>
+        <CalibrationWorkArea />
+      </RequireLogin>
+    </main>
+  );
+};
+
+export default FieldMapCalibrationPage;

--- a/app/routes/admin/field-map-calibration/calibration-page.tsx
+++ b/app/routes/admin/field-map-calibration/calibration-page.tsx
@@ -35,6 +35,44 @@ const PHASES_FOR_CLICK_COUNT: OverlayPhase[] = [
   "ready",
 ];
 
+/**
+ * Corner descriptions use driver-station-relative language ("blue drivers'
+ * right-hand corner") because that's how a human standing at the field
+ * thinks about the geometry. The parenthetical image orientation matches the
+ * project's standard field-image layout: blue on the left, red on the right,
+ * scoring table toward the bottom of the image.
+ */
+const CORNERS = [
+  {
+    code: "A",
+    alliance: "blue" as const,
+    fieldCoord: "(0, 0)",
+    heading: "Blue alliance — driver-right corner",
+    hint: "Near the scoring table. Bottom-left of the field image.",
+  },
+  {
+    code: "B",
+    alliance: "red" as const,
+    fieldCoord: "(L, 0)",
+    heading: "Red alliance — driver-left corner",
+    hint: "Near the scoring table. Bottom-right of the field image.",
+  },
+  {
+    code: "C",
+    alliance: "red" as const,
+    fieldCoord: "(L, W)",
+    heading: "Red alliance — driver-right corner",
+    hint: "Far side from the scoring table. Top-right of the field image.",
+  },
+  {
+    code: "D",
+    alliance: "blue" as const,
+    fieldCoord: "(0, W)",
+    heading: "Blue alliance — driver-left corner",
+    hint: "Far side from the scoring table. Top-left of the field image.",
+  },
+] as const;
+
 function defaultDimensions(year: number) {
   const dims = FIELD_DIMENSIONS_BY_YEAR[year];
   return {
@@ -205,21 +243,31 @@ const CalibrationWorkArea = () => {
 
   const imageUrl = fieldImageForYear(year);
 
-  const phaseHint = (() => {
+  // Which corner index is the user expected to click next, if any.
+  const activeIndex: number | null = (() => {
     switch (phase) {
       case "idle":
-        return "Press Start to begin clicking the four field corners.";
       case "picking-corner-0":
-        return "Click the BLUE origin corner (field 0, 0).";
+        return 0;
       case "picking-corner-1":
-        return "Click the RED origin corner (field L, 0).";
+        return 1;
       case "picking-corner-2":
-        return "Click the RED far corner (field L, W).";
+        return 2;
       case "picking-corner-3":
-        return "Click the BLUE far corner (field 0, W).";
+        return 3;
       case "ready":
-        return "Calibration ready. A robot at (2, 2, 0°) is drawn as a visual sanity check.";
+        return null;
     }
+  })();
+
+  const phaseHint = (() => {
+    if (phase === "ready") {
+      return "Calibration ready. A robot at (2 m, 2 m, 0°) is drawn as a visual sanity check.";
+    }
+    const idx = activeIndex ?? 0;
+    const c = CORNERS[idx]!;
+    const prefix = phase === "idle" ? `Press Start. The first corner is:` : `Next corner:`;
+    return `${prefix} corner ${c.code} — ${c.heading}. ${c.hint}`;
   })();
 
   return (
@@ -303,6 +351,50 @@ const CalibrationWorkArea = () => {
       <fieldset>
         <legend>Calibrate corners</legend>
         <p className="field-calibration-phase">{phaseHint}</p>
+        <table className="field-calibration-corners">
+          <thead>
+            <tr>
+              <th scope="col">Status</th>
+              <th scope="col">Corner</th>
+              <th scope="col">Where to click</th>
+              <th scope="col">Field (m)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {CORNERS.map((c, i) => {
+              const done = i < corners.length;
+              const active = activeIndex === i && phase !== "idle";
+              const rowClass = done
+                ? "corner-row corner-done"
+                : active
+                  ? "corner-row corner-active"
+                  : "corner-row";
+              return (
+                <tr key={c.code} className={rowClass}>
+                  <td className="corner-status-cell">
+                    {done ? (
+                      <span aria-label="Clicked">✓</span>
+                    ) : active ? (
+                      <span aria-label="Next to click">→</span>
+                    ) : (
+                      <span aria-hidden="true">·</span>
+                    )}
+                  </td>
+                  <td>
+                    <span className={`corner-badge corner-badge-${c.alliance}`}>
+                      {c.code}
+                    </span>
+                  </td>
+                  <td>
+                    <strong>{c.heading}.</strong>{" "}
+                    <span className="corner-hint">{c.hint}</span>
+                  </td>
+                  <td className="corner-coord-cell">{c.fieldCoord}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
         <FieldCalibrationOverlay
           imageUrl={imageUrl}
           fieldL={fieldLengthM}

--- a/app/types/FieldCalibration.ts
+++ b/app/types/FieldCalibration.ts
@@ -1,0 +1,34 @@
+/**
+ * One calibration record per FRC season year, mapping the bundled field image
+ * to WPILib blue-origin field metres via a 4-corner homography.
+ *
+ * The `corners` tuple is indexed by click order, which fixes the field-corner
+ * correspondence:
+ *
+ *   corners[0] ↔ field (0,   0)    "Blue origin"
+ *   corners[1] ↔ field (L,   0)    "Red origin"
+ *   corners[2] ↔ field (L,   W)    "Red far"
+ *   corners[3] ↔ field (0,   W)    "Blue far"
+ *
+ * Each `{x, y}` is a normalized image coord in the range [0, 1], with `x=0`
+ * at the left edge of the rendered image and `y=0` at the top.
+ *
+ * `updatedAt` / `updatedByUserId` are server-stamped; clients may send them
+ * but the server ignores whatever the body supplies.
+ */
+export interface FieldCalibration {
+  id?: number | null;
+  year: number;
+  fieldLengthM: number;
+  fieldWidthM: number;
+  robotLengthM: number;
+  robotWidthM: number;
+  corners: [
+    { x: number; y: number },
+    { x: number; y: number },
+    { x: number; y: number },
+    { x: number; y: number },
+  ];
+  updatedAt?: string | null;
+  updatedByUserId?: number | null;
+}

--- a/docs/field-map-calibration.md
+++ b/docs/field-map-calibration.md
@@ -1,0 +1,130 @@
+# Field Map Calibration
+
+## Overview
+
+Field Map Calibration maps the bundled FRC field image to the coordinate system used by WPILib robot telemetry. An admin clicks the four corners of the playing surface on the field image and types the physical field and robot dimensions; the system derives a 2D perspective transform (a **homography**) that any other feature can reuse to project a robot pose in metres onto the field image.
+
+Stage 1 ships the calibration primitive plus a visual sanity check: a robot is drawn at a hardcoded pose of `(2.0 m, 2.0 m, 0°)` on top of the field. Stage 2 (separate plan) consumes the transform to render real telemetry-driven pose playback; see the roadmap at the bottom of this doc.
+
+Implementation plan: [`docs/plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md`](plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md).
+
+## Coordinate Conventions
+
+RavenEye already uses normalized `[0, 1]` image coordinates for strategy strokes (see [`MATCH_STRATEGY_PLAN.md`](MATCH_STRATEGY_PLAN.md)). The calibration extends that convention to a real-world metres reference frame.
+
+### WPILib blue-origin (the "field" frame)
+
+- **Origin** `(0, 0)` — corner of the field closest to the blue alliance's right-hand side (looking from the blue drivers toward red).
+- **+X** along the long side of the field, pointing **blue → red**.
+- **+Y** along the short side, right-handed (looking down). On a standard overhead image (blue left, red right, scoring table near), **+Y visually points up**.
+- Heading `0°` faces **+X**; positive rotation is CCW looking down.
+
+### Normalized image coords
+
+- `(0, 0)` is the top-left of the rendered field image; `(1, 1)` is the bottom-right.
+- Image Y points **down**, opposite of field +Y. The homography handles the flip automatically because the user clicks the corners in a fixed order (see below); no manual sign flip lives in the code.
+
+### Click order (fixed)
+
+| Click | Field coord | Name          |
+|-------|-------------|---------------|
+| 0 (A) | `(0,  0)`   | Blue origin   |
+| 1 (B) | `(L,  0)`   | Red origin    |
+| 2 (C) | `(L,  W)`   | Red far       |
+| 3 (D) | `(0,  W)`   | Blue far      |
+
+`L` = field length (long side). `W` = field width (short side). The admin types both; 2026 defaults come from the REBUILT Game Manual §5.2 (`16.54 m × 8.07 m`) — see [`fieldConstants.ts`](../app/common/field/fieldConstants.ts).
+
+## Calibration Flow
+
+1. Admin navigates to **Admin → Field Map Calibration**.
+2. The page calls `GET /api/field-calibration/{year}`:
+   - On `404`, the page seeds the form with the year's defaults and sits in the `idle` phase.
+   - On `200`, the record hydrates the form and the page jumps straight to the `ready` phase.
+3. Admin presses **Start**. The state machine walks `picking-corner-0 → picking-corner-1 → picking-corner-2 → picking-corner-3`; each phase expects one click on the prescribed corner.
+4. On the fourth click, [`isCalibrationWellFormed`](../app/common/field/homography.ts) rejects degenerate inputs (two corners within ~1% of the image, colinear points, or a self-intersecting "bowtie" click order) and surfaces a reason-specific error. Otherwise the page transitions to `ready`.
+5. `ready` computes the homography once (memoized), renders a 1-metre grid, the coordinate axes, the origin, and the Stage 1 robot pose as a visual proof that the math lines up.
+6. **Save** writes to `PUT /api/field-calibration/{year}`. **Verify transform** runs 5 known field points through `fieldToImageNormalized ∘ imageNormalizedToField` and prints the round-trip delta in millimetres — any delta above ~1 mm is a red flag before Stage 2 starts feeding in real telemetry.
+7. **Reset** (available during picking) clears the clicks and returns to `idle`.
+
+## Homography Math
+
+A 2D homography is a 3×3 matrix `H` with 8 degrees of freedom (the bottom-right entry is pinned to 1) that maps points between two planes under perspective:
+
+```
+[x']   [ h0  h1  h2 ]   [x]
+[y'] = [ h3  h4  h5 ] · [y]
+[w ]   [ h6  h7  1  ]   [1]
+```
+
+The mapped point is `(x'/w, y'/w)`. Four point correspondences give us 8 equations — exactly enough to solve for the 8 unknowns via Gaussian elimination. We use partial pivoting for numerical stability; no external library is involved.
+
+### Concrete example
+
+The identity calibration `field = [(0,0),(1,0),(1,1),(0,1)] → image = [(0,0),(1,0),(1,1),(0,1)]` produces `H = I` and any point maps to itself. Inset the image corners by 10% on each side — `[(0.1,0.1),(0.9,0.1),(0.9,0.9),(0.1,0.9)]` — and by symmetry the field centre `(0.5, 0.5)` still maps to image `(0.5, 0.5)`, but `(0, 0)` now maps to `(0.1, 0.1)`. The math lives in [`homography.ts`](../app/common/field/homography.ts).
+
+### Why four corners, not two
+
+A simple scale+translate (two corners) would be sufficient if the field image were a perfect orthographic view. In practice the bundled images have mild perspective and barrel distortion; a 4-corner homography handles the perspective component exactly and is close enough on the lens distortion for overlay purposes.
+
+### Reference
+
+Hartley & Zisserman, *Multiple View Geometry in Computer Vision*, §4.1 (DLT — Direct Linear Transform).
+
+## Data Model
+
+One row per season year. `UNIQUE(year)` enforces the "one calibration per year" invariant at the DB layer.
+
+**Table: `RB_FIELD_CALIBRATION`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT AUTO_INCREMENT | PK |
+| `year` | INT | `UNIQUE`. FRC season year, e.g. `2026`. |
+| `field_length_m` | DOUBLE | L in metres (long side). |
+| `field_width_m` | DOUBLE | W in metres (short side). |
+| `robot_length_m` | DOUBLE | Robot footprint length. |
+| `robot_width_m` | DOUBLE | Robot footprint width. |
+| `corner0_x`..`corner3_y` | DOUBLE × 8 | Normalized `[0, 1]` image coords, indexed by click order. |
+| `updated_at` | TIMESTAMP(3) | Stamped on insert and on update. |
+| `updated_by_user_id` | BIGINT NULL | Resolved server-side from the auth principal. |
+
+The backend record exposes flat `corner{0..3}{X,Y}` fields; the frontend wraps those in a nested `corners: [{x,y},...]` tuple via helpers in [`rb.ts`](../app/common/storage/rb.ts) (search for "Field Calibration"). The nested shape fits the homography math and iteration better; the flat shape keeps the Micronaut Data mapping trivial with no custom converters.
+
+## API
+
+| Method | Path | Auth | Returns |
+|---|---|---|---|
+| `GET` | `/api/field-calibration/{year}` | `IS_AUTHENTICATED` | `200` `FieldCalibration` or `404` |
+| `PUT` | `/api/field-calibration/{year}` | `ROLE_ADMIN`, `ROLE_SUPERUSER` | `200` `FieldCalibration` |
+
+`PUT` is **upsert**, not create-only. The service looks the record up by year, updates it if found, otherwise inserts — this avoids depending on MySQL `ON DUPLICATE KEY` semantics. The path-year is authoritative; any `year`, `updatedAt`, or `updatedByUserId` in the request body is ignored. The service always stamps audit fields server-side from the `Authentication` principal.
+
+Frontend contract (see [`rb.ts`](../app/common/storage/rb.ts)):
+
+- `getFieldCalibration(year)` resolves to `FieldCalibration | null` — `null` on 404. This **diverges** from the default `rb.ts` throw-on-non-OK idiom because first-page-load legitimately has no record and must be a normal empty state.
+- `saveFieldCalibration(year, cal)` follows the default idiom (throws on any non-OK).
+
+## Colour-Blind Palette Rationale
+
+Per the project's standing rule, overlays must be readable by colour-blind users. The palette in [`global.css`](../app/assets/css/global.css) uses **Paul Tol's "Bright"** set, which is deuteranopia- and protanopia-safe, and **dual-encodes** every identification channel so colour is never the sole signal:
+
+| Element | Colour channel | Non-colour channel |
+|---|---|---|
+| X axis | `--field-axis-x` (blue in light mode) | Thicker stroke than Y |
+| Y axis | `--field-axis-y` (orange) | Thinner stroke than X |
+| Field grid | `--field-grid` (25% opacity) | Thin stroke, 1-metre spacing |
+| Corner markers | `--field-corner` | `A` `B` `C` `D` text labels |
+| Origin | same as X axis | `0,0` text label |
+| Robot body | `--robot-body` (teal) | 4-sided polygon |
+| Robot front | `--robot-front` (yellow) | Triangle shape inside the body |
+
+Dark-mode overrides live in the same file; toggle the OS dark mode with the calibration page open to verify the palette updates live.
+
+## Stage 2 Roadmap (out of scope for this doc; recorded for continuity)
+
+- Add `tournament_id`, `match_level`, `match_number` to `RB_TELEMETRY_SESSION` for linkage to scouting data.
+- Add `GET /api/telemetry/pose/{sessionId}?startTs=…&endTs=…` returning a time-ordered pose series parsed from `RB_TELEMETRY_ENTRY` (`.../pose/x`, `.../pose/y`, `.../pose/angle`).
+- Replace the hardcoded `(2.0, 2.0, 0°)` Stage 1 pose with a telemetry-driven pose keyed on the event-log timestamp.
+- Move robot dimensions from `RB_FIELD_CALIBRATION` to a self-publishing NetworkTables entry on the robot.
+- Install a frontend test runner (vitest leans tiny and Vite-native) if the homography math surface grows.

--- a/docs/plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md
+++ b/docs/plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md
@@ -1,0 +1,571 @@
+---
+title: "Field Map Calibration — Stage 1"
+type: feat
+status: active
+date: 2026-04-17
+origin: "/Users/tony/.claude/plans/smooth-crafting-ritchie.md"
+---
+
+# Field Map Calibration — Stage 1
+
+**Target repos:** RavenEye (frontend, primary) and RavenBrain (backend). All file paths below are relative to the appropriate subrepo root.
+
+## Overview
+
+Robots upload NetworkTables telemetry (`RB_TELEMETRY_SESSION` / `RB_TELEMETRY_ENTRY`) including pose data (x, y, heading). To visually overlay a robot on the field image used by the match-strategy system, the system needs a coordinate transform from **robot field-metres → field-image pixels**. Stage 1 introduces the calibration primitive: an admin clicks the four corners of the field on the bundled image, enters field and robot dimensions, and the system stores a year-keyed calibration record plus a derived homography usable for future overlays.
+
+A hardcoded robot pose of `(2.0 m, 2.0 m, 0°)` is rendered on-page to visually confirm the calibration is correct. Real telemetry playback is out of scope — see Stage 2 hooks at the bottom.
+
+## Problem Frame
+
+The match-strategy system already renders a field image with normalized 0..1 strokes on top (see `RavenEye/docs/MATCH_STRATEGY_PLAN.md:82`). To place robot poses from WPILib-native metres onto that image, the system needs a 2D homography. The field image has mild perspective, so a simple scale/translate is insufficient; a 4-point homography is the right math. Storing the four corner clicks (normalized 0..1 against the image) plus field and robot physical dimensions gives enough to derive the transform on demand.
+
+## Requirements Trace
+
+- **R1.** Admins can calibrate the field for a given season year by clicking four prescribed corners and entering field + robot dimensions.
+- **R2.** Calibration is persisted server-side, one record per year, editable by admins.
+- **R3.** After calibration, the page renders a 1-metre grid, the coordinate axes, and a robot at the hardcoded pose `(2.0 m, 2.0 m, 0°)` so the user can visually confirm correctness.
+- **R4.** The coordinate transform (field metres ↔ normalized image) is implemented as a reusable pure-function module that Stage 2 telemetry playback can consume.
+- **R5.** Calibration data loads on page entry if a record already exists for the selected year.
+- **R6.** 2026 is the first supported year; the data model supports adding future years without schema changes.
+- **R7.** UI adheres to the standing colour-blind-friendly rule (dual-encoded hue + shape/width/label, verified in dark mode).
+
+## Scope Boundaries
+
+- No reading of real telemetry (`RB_TELEMETRY_ENTRY`) or pose playback.
+- No joining telemetry timestamps to `RB_EVENT` rows.
+- No association of telemetry sessions with tournaments or matches.
+- No live tracking, animation, or time scrubbing.
+- No multi-field support (one calibration per year, not per venue).
+
+### Deferred to Separate Tasks
+
+- Schema additions to `RB_TELEMETRY_SESSION` (tournament/match linkage): Stage 2.
+- Backend endpoint for pose series (`GET /api/telemetry/pose/{sessionId}`): Stage 2.
+- Pulling robot dimensions from telemetry (vs. storing on calibration): Stage 2 or 3.
+
+## Context & Research
+
+### Coordinate convention (WPILib blue-origin)
+
+- `(0, 0)` — blue origin: field corner closest to blue alliance's right-hand side looking from blue drivers.
+- `+X` — along the long side, pointing blue → red.
+- `+Y` — along the short side, right-handed (looking down). On a standard overhead image (blue left, red right, scoring table near side), `+Y` visually points *up*.
+- Heading `0°` faces `+X`. Positive rotation is CCW looking down.
+- Image y-axis points down. The homography handles the flip automatically because the user clicks corners in the prescribed order.
+
+### Click order for calibration
+
+| Click | Field coord | Name |
+|-------|-------------|------|
+| 1     | `(0, 0)`    | Blue origin |
+| 2     | `(L, 0)`    | Red origin (same long-side row as click 1) |
+| 3     | `(L, W)`    | Red far |
+| 4     | `(0, W)`    | Blue far |
+
+`L` = field length (long side, metres). `W` = field width (short side, metres). Entered on the page; 2026 defaults from the REBUILT Game Manual §5.2 below.
+
+### Relevant Code and Patterns
+
+- **Auth + user-id extraction idiom:** `RavenBrain/src/main/java/ca/team1310/ravenbrain/matchstrategy/MatchStrategyApi.java:100-127` (handler signature with `Authentication`) and `:204-208` (`resolveUser(authentication)` → `userService.findByLogin(authentication.getName())`).
+- **Service + repo split pattern to follow:** `ca.team1310.ravenbrain.strategyarea` — separate `StrategyArea` entity, `StrategyAreaRepository` (`@JdbcRepository`), `StrategyAreaService` (`@Singleton` wrapping the repo). *Do not* follow `MatchStrategyPlanService`'s combined service-plus-repo pattern.
+- **Test infrastructure:** `RavenBrain/src/test/java/ca/team1310/ravenbrain/matchstrategy/MatchStrategyApiTest.java` — `@MicronautTest`, `HttpClient` injection, `TestUserHelper`, Testcontainers auto-provisioned via `io.micronaut.test-resources`.
+- **Normalized 0..1 coords precedent:** `RavenEye/docs/MATCH_STRATEGY_PLAN.md:82` — strategy strokes already use the same normalization convention.
+- **Field image helper (already exists):** `RavenEye/app/common/strategy/fieldImage.ts:31-38` exports `fieldImageForYear(year: number)` with sensible year-fallback logic. Reuse as-is; no modification needed.
+- **`rb.ts` fetch idiom:** `RavenEye/app/common/storage/rb.ts:1011-1019` (`getTeamSummaryReport`) — `rbfetch`, typed cast, `throw new Error(...)` on non-OK. Stage 1's `getFieldCalibration` diverges on 404 only (see Unit 5).
+- **Strategy canvas (avoided):** `StrategyCanvas.tsx` and `StrategyReadOnlyCanvas.tsx` — HTML canvas-based. Unsuitable for this feature because DOM click events with normalized SVG coordinates are easier to reason about and test than canvas coordinate math.
+- **Dark mode convention:** `RavenEye/app/assets/css/global.css:88` (`@media (prefers-color-scheme: dark)`) overrides CSS custom property values on `:root`.
+
+### Institutional Learnings
+
+No directly applicable entries in `docs/solutions/`. This is the first coordinate-transform feature in the project.
+
+### External References
+
+- **2026 REBUILT Game Manual §5.2** (cited in prior design): field playing surface 651.2 in × 317.7 in ≈ **16.54 m × 8.07 m**. User can override on the page.
+- **4-point homography math:** standard 8-unknowns linear system. Reference: Hartley & Zisserman *Multiple View Geometry* §4.1 (DLT). Any homography cookbook; no library dependency needed.
+
+## Key Technical Decisions
+
+- **Normalized [0..1] image coords, not pixels** — decouples calibration from image pixel resolution and mirrors the existing strategy-strokes convention.
+- **Per-year, one-record-per-year schema** (`UNIQUE(year)`) — matches the "one field image per year" reality; Stage 2 can add venue linkage if needed.
+- **Four separate corner columns, not JSON** — trivial with Micronaut Data, no custom converter, queryable if ever needed.
+- **Split Service + Repo (StrategyArea pattern)** — clearer layering than the combined MatchStrategyPlanService approach and easier to unit-test the service in isolation later.
+- **`upsert` implemented as `findByYear().map(update).orElseGet(insert)`** — avoids relying on MySQL `ON DUPLICATE KEY` and keeps audit fields stamped server-side.
+- **`getFieldCalibration` returns `null` on 404**, not throws — first page load is legitimately "no calibration yet" and must be a normal empty state, not an error path. Diverges from the default `rb.ts` idiom; commented inline.
+- **SVG overlay with `viewBox="0 0 1 1"` + `preserveAspectRatio="none"`**, over (not instead of) an `<img>` — click coordinates land in normalized 0..1 space for free. CSS must pin SVG and image to the same rendered rect (see Unit 6 approach).
+- **Homography degeneracy check** — validate that the 4 clicks form a convex quadrilateral with minimum edge length before computing the transform. Surface a helpful error otherwise rather than producing NaN-filled overlays.
+- **No frontend test runner** — RavenEye has none (`package.json` has no test script). Math verification is an in-page "Verify transform" button that round-trips known points and displays delta in millimetres. Doc-comment sanity checks supplement but do not substitute.
+- **Colour-blind palette is dual-encoded** — hue + shape (triangle for robot front), hue + width (X axis thicker than Y), hue + label (letter labels on corners).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **What homography library?** — None. A ~60-line pure-JS Gaussian-elimination solver handles the 8×9 system; keeps the "minimal external deps" constraint.
+- **Where does the plan document live?** — `RavenEye/docs/plans/` (primary-repo convention). The `docs/plans/` directory is created by this plan's first landing.
+- **Role gate for PUT?** — `ROLE_ADMIN` or `ROLE_SUPERUSER` (matches `StrategyAreaApi` precedent). GET is `IS_AUTHENTICATED` (calibration data is not sensitive within the team).
+- **GET 404 vs 200-with-null?** — 404 on the wire, `null` at the helper layer. See Key Technical Decisions.
+
+### Deferred to Implementation
+
+- Exact CSS rules for `.field-map` container (approach is set; precise flex/grid tuning happens on-screen).
+- Whether the "Verify transform" button reuses the same homography object or recomputes — minor perf detail.
+- Precise error-message copy for degenerate-quad rejection — wording finalized when UX lands.
+- Whether the field image aspect ratio matches 2.05:1 closely enough to skip letterboxing workarounds — verified visually during Unit 7 testing.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+┌───────────────────────── Browser (admin) ──────────────────────────┐
+│                                                                    │
+│   FieldMapCalibrationPage                                          │
+│   ├── Year + dimensions form                                       │
+│   ├── FieldCalibrationOverlay (img + svg siblings, pinned)         │
+│   │      click → normalized (nx, ny) → page state                  │
+│   └── on all-4-clicks: computeHomography(fieldCorners, imgCorners) │
+│          │                                                         │
+│          ▼                                                         │
+│   homography.ts (pure)                                             │
+│   ├── computeHomography(src, dst)                                  │
+│   ├── applyHomography(h, p)                                        │
+│   ├── fieldToImageNormalized(cal)                                  │
+│   └── imageNormalizedToField(cal)                                  │
+│          │                                                         │
+│          ▼                                                         │
+│   Render grid, axes, robot at (2.0, 2.0, 0°) as SVG polygons       │
+│          │                                                         │
+│          ▼ PUT /api/field-calibration/{year}                       │
+└────────────────────────────┬───────────────────────────────────────┘
+                             │
+                             ▼
+┌───────────────────────── RavenBrain ───────────────────────────────┐
+│   FieldCalibrationApi  ──(AuthN, role guard)──▶ resolveUser()      │
+│          │                                                         │
+│          ▼                                                         │
+│   FieldCalibrationService.upsert(cal, userId)                      │
+│          │ findByYear().map(update).orElseGet(insert)              │
+│          ▼                                                         │
+│   FieldCalibrationRepository  ──▶ RB_FIELD_CALIBRATION (MySQL)     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Database migration for `RB_FIELD_CALIBRATION`**
+
+**Goal:** Add the schema that stores one calibration record per season year.
+
+**Requirements:** R2, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `RavenBrain/src/main/resources/db/migration/V27__field_calibration.sql`
+
+**Approach:**
+- `year INT NOT NULL UNIQUE` enforces one-per-year at the DB layer.
+- Four corners stored as eight `DOUBLE NOT NULL` columns (`corner0_x` … `corner3_y`), normalized 0..1.
+- `updated_at TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)` gives free audit.
+- `updated_by_user_id BIGINT NULL` — nullable because first-run seeding (future) may skip it.
+- No FK to `RB_USER` — matches existing patterns in peer tables (avoids cascade churn).
+
+**Patterns to follow:**
+- `RavenBrain/src/main/resources/db/migration/V23__match_strategy_plan.sql` for column ordering and audit-field style.
+
+**Test scenarios:**
+- *Integration:* `./gradlew build` runs Flyway and migration applies cleanly on a fresh Testcontainers MySQL.
+- *Integration:* `UNIQUE(year)` rejects a second insert for the same year with a constraint violation.
+
+**Verification:**
+- `./gradlew build` succeeds.
+- Fresh schema shows `RB_FIELD_CALIBRATION` with 11 columns plus the two audit fields.
+
+---
+
+- [ ] **Unit 2: Backend `fieldcalibration` package (entity, repo, service, API)**
+
+**Goal:** Provide REST endpoints for reading and upserting a calibration record.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `RavenBrain/src/main/java/ca/team1310/ravenbrain/fieldcalibration/FieldCalibration.java`
+- Create: `RavenBrain/src/main/java/ca/team1310/ravenbrain/fieldcalibration/FieldCalibrationRepository.java`
+- Create: `RavenBrain/src/main/java/ca/team1310/ravenbrain/fieldcalibration/FieldCalibrationService.java`
+- Create: `RavenBrain/src/main/java/ca/team1310/ravenbrain/fieldcalibration/FieldCalibrationApi.java`
+
+**Approach:**
+- `FieldCalibration` — `@MappedEntity("RB_FIELD_CALIBRATION")` record. Corners as eight `double` fields, not nested objects, to keep Micronaut Data mapping trivial.
+- `FieldCalibrationRepository` — `@JdbcRepository(dialect = MYSQL)` extending `CrudRepository<FieldCalibration, Long>` with `Optional<FieldCalibration> findByYear(int year)`.
+- `FieldCalibrationService` — `@Singleton`, thin wrapper. Key method: `upsert(FieldCalibration cal, long userId)` implemented as `findByYear(cal.year).map(existing -> save(copyWithAudit(existing, cal, userId))).orElseGet(() -> save(cal.withAudit(userId)))` — avoids relying on MySQL ON DUPLICATE KEY and ensures audit fields are always stamped server-side.
+- `FieldCalibrationApi` — `@Controller("/api/field-calibration")`:
+  - `GET /{year}`: `@Secured(SecurityRule.IS_AUTHENTICATED)`. Returns 404 if no record.
+  - `PUT /{year}`: `@Secured({"ROLE_ADMIN", "ROLE_SUPERUSER"})`. Body is `FieldCalibration`. `userId` is resolved server-side from `Authentication` — never trusted from the request body.
+- Mirror the `Authentication` → `User` idiom from `MatchStrategyApi.java:100-127, 204-208` (`resolveUser(authentication)` → `userService.findByLogin(authentication.getName())`).
+- Mirror the **split** service/repo pattern from `ca.team1310.ravenbrain.strategyarea`, not the combined pattern in `MatchStrategyPlanService`.
+
+**Patterns to follow:**
+- Package structure: `ca.team1310.ravenbrain.strategyarea` (StrategyArea.java, StrategyAreaRepository.java, StrategyAreaService.java, StrategyAreaApi.java).
+- Auth + user resolution: `ca.team1310.ravenbrain.matchstrategy.MatchStrategyApi`.
+
+**Test scenarios:** *(covered in Unit 3 — kept together so the API and its tests land as one PR)*
+
+**Verification:**
+- `./gradlew compileJava` clean.
+- Endpoints respond as spec'd in manual smoke test (curl).
+
+---
+
+- [ ] **Unit 3: Backend tests for `FieldCalibrationApi`**
+
+**Goal:** Exercise happy-path CRUD and auth enforcement against a real Testcontainers MySQL.
+
+**Requirements:** R1, R2 (auth)
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `RavenBrain/src/test/java/ca/team1310/ravenbrain/fieldcalibration/FieldCalibrationApiTest.java`
+
+**Approach:**
+- `@MicronautTest`, inject `HttpClient`, `FieldCalibrationService`, `TestUserHelper`.
+- Each test builds its user via `TestUserHelper` with the required role.
+- Assertions use JUnit 5 + Micronaut `HttpResponse` inspection.
+
+**Execution note:** Test-first — write the auth-enforcement cases before implementing the service, then fill in happy-path assertions.
+
+**Patterns to follow:**
+- `RavenBrain/src/test/java/ca/team1310/ravenbrain/matchstrategy/MatchStrategyApiTest.java` — identical injection set, identical HttpClient usage pattern.
+
+**Test scenarios:**
+- *Happy path:* PUT as ADMIN creates a record; GET as MEMBER retrieves the same corners and dimensions.
+- *Happy path:* Second PUT as ADMIN for the same year updates the existing record (no constraint violation); `updatedAt` advances and `updatedByUserId` reflects the second user.
+- *Happy path:* PUT as SUPERUSER also succeeds (both roles permitted).
+- *Error path:* GET with no auth → 401.
+- *Error path:* GET for a year with no record → 404 (expected, not an error in the product sense but verified at the API).
+- *Error path:* PUT as MEMBER → 403.
+- *Error path:* PUT as DATASCOUT → 403.
+- *Error path:* PUT with no auth → 401.
+- *Error path:* PUT with mismatched `year` in body vs. path → 400 (or treat body year as authoritative — pick one and document inline).
+- *Integration:* server-stamped `updatedByUserId` matches the authenticated caller's id, even if the request body tries to supply a different value.
+
+**Verification:**
+- `./gradlew test --tests "ca.team1310.ravenbrain.fieldcalibration.FieldCalibrationApiTest"` green.
+- No Testcontainers leaks (container stops between runs).
+
+---
+
+- [ ] **Unit 4: Frontend homography math module**
+
+**Goal:** Pure-function coordinate-transform module usable by Stage 1's page and Stage 2's playback.
+
+**Requirements:** R4
+
+**Dependencies:** None (self-contained)
+
+**Files:**
+- Create: `RavenEye/app/common/field/homography.ts`
+
+**Approach:**
+- Exports: `type Point`, `type Homography = number[]` (9 elements, row-major 3×3), `computeHomography(src, dst)`, `applyHomography(h, p)`, `fieldToImageNormalized(cal)`, `imageNormalizedToField(cal)`.
+- `computeHomography`: build the 8×9 system from 4 correspondences, row-reduce via Gaussian elimination, normalize `h33 = 1`. No external library.
+- Both convenience factories derive field corners in metres from `cal` and return a memoizable `(p) => p` function.
+- **Degeneracy check (exported as `isCalibrationWellFormed(corners, minEdgeNormalized = 0.01)`):**
+  - All four points pairwise distinct and separated by at least `minEdgeNormalized` in normalized units.
+  - The four points in click order form a convex (non-self-intersecting) quadrilateral — verified by sign-consistency of the cross products of consecutive edges.
+  - Returns `{ ok: true } | { ok: false, reason: "colinear" | "too-close" | "self-intersecting" }` so the UI can surface a specific message.
+- Page code calls `isCalibrationWellFormed` before calling `computeHomography` and never feeds a degenerate quad into the solver.
+- Sanity-check comment block at the top of the file: "identity corners round-trip" and "unit-square maps to unit-square" manually traced — lightweight compensation for the missing test runner.
+
+**Patterns to follow:**
+- `RavenEye/app/common/strategy/` modules for the "pure TS helpers with no React dependencies" style.
+
+**Test scenarios:**
+- RavenEye has no test runner, so these scenarios are executed as (a) the in-page Verify button in Unit 7, and (b) hand-traced in the module's doc comment:
+  - *Happy path:* Identity quad (corners = `{(0,0),(1,0),(1,1),(0,1)}`, field `1×1`) maps `(0.5, 0.5)` to `(0.5, 0.5)`.
+  - *Happy path:* Field corners round-trip to image corners exactly (within 1e-9).
+  - *Happy path:* Inverse composed with forward is the identity (within 1e-9) for a representative perspective quad.
+  - *Edge case:* `isCalibrationWellFormed` rejects 4 colinear points with `reason: "colinear"`.
+  - *Edge case:* `isCalibrationWellFormed` rejects two points within `minEdgeNormalized` with `reason: "too-close"`.
+  - *Edge case:* `isCalibrationWellFormed` rejects a self-intersecting bowtie ordering with `reason: "self-intersecting"`.
+
+**Verification:**
+- `npm run typecheck` clean.
+- Verify button in Unit 7 shows round-trip deltas under 1 mm for 2026 field dimensions.
+
+---
+
+- [ ] **Unit 5: Frontend shared primitives (type, constants, `rb.ts` helpers)**
+
+**Goal:** Shared types, year defaults, and API client helpers the calibration page and future Stage 2 playback will consume.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 2 (API shape)
+
+**Files:**
+- Create: `RavenEye/app/types/FieldCalibration.ts`
+- Create: `RavenEye/app/common/field/fieldConstants.ts`
+- Modify: `RavenEye/app/common/storage/rb.ts`
+
+**Approach:**
+- `FieldCalibration.ts`: interface with `year`, `fieldLengthM`, `fieldWidthM`, `robotLengthM`, `robotWidthM`, and a 4-tuple `corners: [{x,y},{x,y},{x,y},{x,y}]` documented with the click-order mapping in a leading comment. Optional `updatedAt` and `updatedByUserId`.
+- `fieldConstants.ts`: `FIELD_DIMENSIONS_BY_YEAR: Record<number, { lengthM: number; widthM: number }>` with `2026: { lengthM: 16.54, widthM: 8.07 }` per the Game Manual. `DEFAULT_ROBOT_DIMENSIONS_M = { lengthM: 0.84, widthM: 0.84 }`.
+- `rb.ts` additions:
+  - `getFieldCalibration(year: number): Promise<FieldCalibration | null>` — **returns `null` on 404**, throws on any other non-OK. This is an intentional divergence from the default `rbfetch`-and-throw idiom and is commented as such inline. Rationale: first page load legitimately has no record and must not look like an error.
+  - `saveFieldCalibration(year: number, cal: FieldCalibration): Promise<FieldCalibration>` — follows the standard idiom (throws on non-OK).
+
+**Patterns to follow:**
+- `RavenEye/app/common/storage/rb.ts:1011-1019` (`getTeamSummaryReport`) for the standard non-OK-throws idiom.
+- `RavenEye/app/types/` for type-file style (interface-per-file, no defaults bundled in).
+
+**Test scenarios:**
+- *Happy path:* `getFieldCalibration(2026)` returns the saved record after Unit 7's page saves one.
+- *Edge case:* `getFieldCalibration(2099)` returns `null` (no record exists), not a thrown error.
+- *Error path:* `getFieldCalibration` on 500 throws a useful `Error` (not swallowed).
+- *Integration:* `saveFieldCalibration` round-trips through `PUT /api/field-calibration/{year}` and the response matches the sent body (modulo audit fields).
+
+**Verification:**
+- `npm run typecheck` clean.
+- Manual DevTools: console call to `getFieldCalibration(9999)` resolves to `null`.
+
+---
+
+- [ ] **Unit 6: `FieldCalibrationOverlay` component + overlay CSS**
+
+**Goal:** Render the field image with a click-capturing, normalized-coordinate SVG overlay. Render picked corners during calibration and grid + axes + robot when calibration is ready.
+
+**Requirements:** R1, R3, R7
+
+**Dependencies:** Units 4, 5
+
+**Files:**
+- Create: `RavenEye/app/routes/admin/field-map-calibration/FieldCalibrationOverlay.tsx`
+- Modify: `RavenEye/app/assets/css/components.css`
+
+**Approach:**
+- Component props: `imageUrl`, `fieldL`, `fieldW`, `robotL`, `robotW`, `corners`, `phase`, `onCornerClick`.
+- DOM: `<div className="field-map"> <img /> <svg viewBox="0 0 1 1" preserveAspectRatio="none" /> </div>`.
+- **CSS alignment — critical:** the SVG and image must occupy the *same rendered rect*, otherwise click coordinates drift. Approach:
+  ```
+  .field-map {
+    position: relative;
+    width: 100%;                /* parent controls size */
+    aspect-ratio: 16.54 / 8.07; /* 2026 field; param if it varies later */
+  }
+  .field-map img,
+  .field-map svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+  ```
+  Setting `aspect-ratio` on the container avoids letterboxing inside `object-fit: contain`: the container is sized to the field aspect, the image fills it exactly, and the SVG sits directly on top with the same rect. If the bundled `field.png` does not match the field aspect ratio closely, Unit 7's verification will surface the mismatch visually.
+- Click handler: `rect = e.currentTarget.getBoundingClientRect(); onCornerClick({ x: (e.clientX - rect.left)/rect.width, y: (e.clientY - rect.top)/rect.height })`.
+- Picked-corner indicator: `<circle r="0.006" />` + adjacent `<text>` with letters `A`, `B`, `C`, `D`.
+- Ready-state rendering (all four clicks complete OR loaded from server): grid polylines at integer-metre lines, X and Y axis lines (X thicker than Y), origin marker, robot polygon via `fieldToImageNormalized(cal)` applied to the 4 robot-rect corners, front-indicator triangle inside the polygon.
+- Robot-rect corners helper (local to the component):
+  ```
+  robotCornersInField(cx, cy, heading, l, w):
+    local = [(-hl,-hw),(+hl,-hw),(+hl,+hw),(-hl,+hw)]
+    rotate each by heading around (cx, cy)
+    return rotated+translated field points
+  ```
+  Each field point goes through `fieldToImageNormalized` to produce the normalized polygon.
+- Front-indicator triangle: base on the front edge narrowed to ~40% centred, apex pointing inward ~20% of robot length. All three vertices lie inside the robot polygon so the outer shape stays a quadrilateral.
+
+**Patterns to follow:**
+- Overall component-file style: peer components in `RavenEye/app/routes/admin/**`.
+- CSS custom-property conventions: existing `global.css` / `components.css` patterns, `:root` defaults plus `@media (prefers-color-scheme: dark)` overrides.
+
+**Test scenarios:**
+- *Happy path:* In `idle` phase with zero clicks, SVG shows no overlay elements; clicks produce normalized coords in 0..1.
+- *Happy path:* After four clicks, overlay renders grid, axes, origin marker, robot polygon, and front triangle.
+- *Happy path:* Loading an existing calibration skips `idle`/`picking-*` and shows the ready overlay directly.
+- *Edge case:* Window resize: click at the same pixel produces the same normalized coord as before resize (verified by clicking, resizing, clicking same on-screen feature again).
+- *Edge case:* A click registered just inside the corner of the image yields a normalized coord ≥0 and ≤1 (no negative or >1 values due to CSS overflow).
+- *Integration:* Hardcoded pose `(2.0 m, 2.0 m, 0°)` renders as a quad centred at the `(2, 2)` grid intersection with its front edge facing +X.
+
+**Verification:**
+- Visual: 1-metre grid aligns with real field features (alliance wall, scoring zone corners) within a few px.
+- Visual: robot front faces the red alliance side in the overlay.
+- Colour-blind check: page is readable in deuteranopia simulator (Coblis or Chrome Vision Simulator) in both light and dark modes.
+
+---
+
+- [ ] **Unit 7: `FieldMapCalibrationPage` + route + Verify button**
+
+**Goal:** The admin page that drives the calibration flow, wires form state to the overlay, persists to the API, and provides user-facing math verification.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Units 2, 4, 5, 6
+
+**Files:**
+- Create: `RavenEye/app/routes/admin/field-map-calibration/calibration-page.tsx`
+- Modify: `RavenEye/app/routes.ts`
+
+**Approach:**
+- Route: add `route("admin/field-map-calibration", "./routes/admin/field-map-calibration/calibration-page.tsx")` immediately after the `admin/match-videos` routes (around `routes.ts:54-55`).
+- Page wraps content in `RequireLogin` and lays out four cards: Year, Field dimensions, Robot dimensions, Calibrate corners (holding the overlay plus Reset/Save/Verify buttons).
+- State machine: `idle → picking-corner-0 → picking-corner-1 → picking-corner-2 → picking-corner-3 → ready`. Load path jumps straight to `ready` when a record exists.
+- On mount: call `getFieldCalibration(selectedYear)`. `null` → `idle` state with defaults pre-filled. Record → hydrate state and jump to `ready`.
+- On fourth click: call `isCalibrationWellFormed(corners)`. If `ok: false`, show reason-specific inline error and stay in `picking-corner-3` (user resets or re-clicks). If `ok: true`, transition to `ready` and compute the homography via `useMemo` keyed on `calibration`.
+- Hardcoded pose constant at the top of the file: `const STAGE_1_FIXED_POSE = { xm: 2.0, ym: 2.0, headingDeg: 0 };`. Degrees-to-radians conversion happens at the call site to the overlay.
+- Field image URL: `fieldImageForYear(selectedYear)` from `RavenEye/app/common/strategy/fieldImage.ts` — already exists with year-fallback logic.
+- **Verify button** (in the ready state): runs four round-trips through `fieldToImageNormalized` composed with `imageNormalizedToField` on known field points `(0,0)`, `(L,0)`, `(L,W)`, `(0,W)`, and `(L/2, W/2)`. Displays each delta as millimetres. Expected: all deltas well under 1 mm for a well-formed calibration. Surfaces numerical problems before they become mysterious playback bugs in Stage 2.
+- Save button: `saveFieldCalibration(year, {...})`, disabled unless `ready`.
+- Reset button: clears clicks and returns to `idle`. No confirm dialog — Save is the only durable action.
+
+**Patterns to follow:**
+- `RavenEye/app/routes/admin/match-videos/*` for page structure and `RequireLogin` usage.
+- Page-level `useMemo` for derived transforms (StrategyCanvas and peers do similar).
+
+**Test scenarios:**
+- *Happy path:* Load page as ADMIN with no existing calibration → defaults populate, state is `idle`, overlay is clickable.
+- *Happy path:* Click four corners in order → page reaches `ready`; overlay shows grid, axes, robot at `(2, 2, 0°)`.
+- *Happy path:* Save → success. Reload page → calibration is restored, state starts in `ready`, robot is at `(2, 2, 0°)` in the same place.
+- *Happy path:* Verify button shows sub-millimetre deltas for all five test points.
+- *Happy path:* Change year to a year with no calibration → state resets to `idle` (not stuck on the previous year's calibration).
+- *Edge case:* Click four colinear points → error message appears, page stays in `picking-corner-3`, Save is disabled.
+- *Edge case:* Click two corners at the same pixel → error message appears, Save is disabled.
+- *Edge case:* Click four bowtie-ordered corners → error message appears with `self-intersecting` reason.
+- *Edge case:* Resize the window mid-calibration → picked corners stay visually attached to the features they were clicked on.
+- *Error path:* API returns 500 on Save → user sees an error banner; calibration is not lost from local state (can retry).
+- *Error path:* Non-admin user navigates to the page → they see the page but Save errors with 403 on attempt (acceptable for Stage 1; Stage 2 may hide the page entirely).
+- *Integration:* PUT payload `updatedByUserId` field is ignored if set by the client; server-stamped value is what comes back on GET.
+- *Integration:* Field image aspect ratio roughly matches the 2026 field (16.54 × 8.07 ≈ 2.05:1) — 1-metre grid lines up with visible field features without visible skew.
+
+**Verification:**
+- `npm run typecheck` clean.
+- Manual: full calibration flow for 2026 end-to-end in dev (`npm run dev` + local `docker compose up -d`).
+- Verify button reports sub-millimetre round-trip deltas.
+- Dark-mode pass and colour-blind simulator pass (per R7).
+- On iPhone 5-ish viewport (360 px wide), the page does not horizontally scroll; calibration clicks still land where expected (lower UX priority per project constraints but worth eyeballing).
+
+---
+
+- [ ] **Unit 8: CSS custom properties for field + robot palette**
+
+**Goal:** Introduce the colour-blind-friendly palette variables used by the overlay, in both light and dark modes.
+
+**Requirements:** R7
+
+**Dependencies:** None (can land before or with Unit 6)
+
+**Files:**
+- Modify: `RavenEye/app/assets/css/components.css` (or `global.css` if the shop is for page-level vs. component-level; pick to match surrounding conventions — existing CSS structure dictates)
+
+**Approach:**
+- Add to `:root` (light defaults):
+
+  | Property | Light value |
+  |----------|-------------|
+  | `--field-grid` | `rgba(0, 0, 0, 0.25)` |
+  | `--field-axis-x` | `#0077BB` |
+  | `--field-axis-y` | `#EE7733` |
+  | `--field-corner` | `#CC3311` |
+  | `--robot-body` | `#009988` |
+  | `--robot-front` | `#EEDD00` |
+
+- Override in `@media (prefers-color-scheme: dark)`:
+
+  | Property | Dark value |
+  |----------|------------|
+  | `--field-grid` | `rgba(255, 255, 255, 0.25)` |
+  | `--field-axis-x` | `#33BBEE` |
+  | `--field-axis-y` | `#EE7733` |
+  | `--field-corner` | `#EE3377` |
+  | `--robot-body` | `#44BB99` |
+  | `--robot-front` | `#EEDD00` |
+
+- All overlay SVG elements use `var(--…)` rather than hardcoded hex, so the palette can be tweaked in one place.
+- Dual-encoding, enforced by Unit 6's markup (not by CSS): X axis thicker than Y axis; robot-front is a triangle (shape) plus the `--robot-front` fill (colour); corner markers carry `A/B/C/D` text labels; origin marker has a `0,0` label.
+
+**Patterns to follow:**
+- `RavenEye/app/assets/css/global.css:88` for the `@media (prefers-color-scheme: dark)` override convention.
+
+**Test scenarios:** `Test expectation: none — this unit introduces design tokens only; behavioural coverage lives in Unit 6 (rendering) and Unit 7 (dark-mode + colour-blind verification).`
+
+**Verification:**
+- `npm run typecheck` clean (CSS doesn't affect it, but confirms nothing else broke).
+- Manual: toggle system dark mode with the calibration page open; palette updates live.
+
+---
+
+- [ ] **Unit 9: Design doc**
+
+**Goal:** Per the standing rule, create a RavenEye design doc explaining the feature for future maintainers (especially students).
+
+**Requirements:** Housekeeping — supports long-term maintainability.
+
+**Dependencies:** Unit 7 (doc is written after the design has settled)
+
+**Files:**
+- Create: `RavenEye/docs/field-map-calibration.md`
+
+**Approach:**
+- Sections: Overview, Coordinate Conventions (with ASCII/diagram), Calibration Flow, Homography Math (link to Hartley-Zisserman), Data Model, API, Colour-blind Palette Rationale, Stage 2 Roadmap.
+- Cross-link to this plan: `See docs/plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md` for implementation unit history.
+- Keep the math section readable to a student — concrete example with numbers, not just matrix notation.
+
+**Patterns to follow:**
+- `RavenEye/docs/MATCH_STRATEGY_PLAN.md` — voice, depth, length.
+
+**Test scenarios:** `Test expectation: none — documentation only.`
+
+**Verification:**
+- A student (or a non-author teammate) can read the doc and explain what the feature does and where its boundaries are.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New endpoints under `/api/field-calibration/*` only; no changes to existing request handlers or middleware. Frontend adds a new admin route; no existing routes change.
+- **Error propagation:** `getFieldCalibration` surfaces 404 as `null` — callers must handle that case (Stage 2 playback should also tolerate `null` and either prompt for calibration or use a fallback).
+- **State lifecycle risks:** None — calibration is a single row per year with no concurrent writers in practice (one team admin at a time). Server-side `updated_at` is advisory, not a pessimistic lock.
+- **API surface parity:** No analogous interfaces to update (no other coordinate transforms exist).
+- **Integration coverage:** Unit 3 covers auth boundaries; Unit 7's Verify button covers the pure-math round-trip under realistic calibration; Unit 6's visual grid-alignment is the integration proof that the whole stack agrees on coordinates.
+- **Unchanged invariants:** `RB_TELEMETRY_SESSION`, `RB_TELEMETRY_ENTRY`, `RB_EVENT`, match-strategy strokes, and the existing strategy canvas are **not** touched. The existing normalized-0..1 convention for strategy strokes is *consistent with* the new calibration convention but the two are not yet coupled; Stage 2 will bridge them.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| User clicks 4 degenerate points (colinear, overlapping, bowtie) and overlay fills with NaN | `isCalibrationWellFormed` gate before `computeHomography`; reason-specific error UI (Units 4, 7) |
+| SVG and image drift under window resize or unusual image aspect ratio → clicks land in the wrong place | Container with explicit `aspect-ratio` + absolutely-positioned overlapping SVG (Unit 6); manual resize test in Unit 7 scenarios |
+| `field.png` aspect ratio differs from the configured field dimensions → 1-metre grid looks off even with perfect math | Unit 7 verification step explicitly compares grid to visible field features; if the bundled image is mis-proportioned, replace it (separate task) |
+| Homography numerical stability on near-degenerate (but not caught) quads | Verify button in Unit 7 displays round-trip deltas; any delta above ~1 mm is a red flag investigators can see |
+| No frontend test runner means regressions in the homography module could slip in silently | Doc-comment traced examples + always-visible Verify button in the admin UI; Stage 2 plan should include installing a test runner if the math surface grows |
+| Second PUT for same year hits `UNIQUE(year)` constraint violation if service logic is wrong | Service uses `findByYear().map(update).orElseGet(insert)` (Unit 2); Unit 3 explicitly tests second PUT |
+| User navigates away mid-calibration and loses clicks | Acceptable for Stage 1 (admin can re-click quickly); no browser-unload warning |
+
+## Documentation / Operational Notes
+
+- New admin-only page — no user-visible impact for scouts.
+- No feature flag; the page simply appears in the admin nav once deployed.
+- Migration is additive and backward-compatible; rollback is manual SQL (`DROP TABLE RB_FIELD_CALIBRATION`) but not expected.
+- Update `RavenEye/docs/field-map-calibration.md` in the same PR (Unit 9).
+
+## Sources & References
+
+- **Origin document:** [/Users/tony/.claude/plans/smooth-crafting-ritchie.md](/Users/tony/.claude/plans/smooth-crafting-ritchie.md)
+- **Related code (backend):** `RavenBrain/src/main/java/ca/team1310/ravenbrain/strategyarea/`, `RavenBrain/src/main/java/ca/team1310/ravenbrain/matchstrategy/MatchStrategyApi.java`
+- **Related code (frontend):** `RavenEye/app/common/strategy/fieldImage.ts`, `RavenEye/app/common/storage/rb.ts`, `RavenEye/app/routes/admin/match-videos/`
+- **Related docs:** `RavenEye/docs/MATCH_STRATEGY_PLAN.md` (normalized-0..1 coord precedent, line 82)
+- **External:** 2026 REBUILT Game Manual §5.2 (field dimensions); Hartley & Zisserman, *Multiple View Geometry*, §4.1 (DLT homography)
+
+## Stage 2 Hooks (out of scope — recorded for continuity)
+
+- Add `tournament_id`, `match_level`, `match_number` to `RB_TELEMETRY_SESSION` for linkage to scouting data.
+- Add `GET /api/telemetry/pose/{sessionId}?startTs=…&endTs=…` returning a time-ordered pose series parsed from `RB_TELEMETRY_ENTRY` (`.../pose/x`, `.../pose/y`, `.../pose/angle`).
+- Replace the hardcoded `(2.0, 2.0, 0°)` pose with a telemetry-driven pose keyed on the event-log timestamp.
+- Move robot dimensions from `RB_FIELD_CALIBRATION` to a self-publishing NT entry on the robot.
+- Install a frontend test runner (vitest leans tiny and Vite-native) if the math surface area grows in Stage 2+.


### PR DESCRIPTION
Admin page at `/admin/field-map-calibration` walks through a 4-click corner calibration, derives a pure-TS homography, and renders a 1-metre grid, coordinate axes, and a fixed robot pose at (2, 2, 0°) as a visual sanity check.

## What's included

- **Homography math** (`app/common/field/homography.ts`): 4-point DLT solver with Gaussian elimination (no external deps). `isCalibrationWellFormed` rejects colinear/too-close/bowtie click orders before they reach the solver.
- **Types & API client** (`app/types/FieldCalibration.ts`, `app/common/field/fieldConstants.ts`, `app/common/storage/rb.ts`): `getFieldCalibration` returns `null` on 404 (intentional divergence from the default idiom — first load legitimately has no record); `saveFieldCalibration` follows the standard throw-on-non-OK idiom.
- **Overlay component** (`FieldCalibrationOverlay.tsx`): field image + normalized 0..1 SVG overlay, pinned to the same rect via `aspect-ratio` + absolute positioning. Clicks produce normalized image coords directly.
- **Calibration page** (`calibration-page.tsx`): state machine (`idle → picking-corner-0..3 → ready`), Reset/Save/Verify buttons, admin-menu entry, route wiring. **Verify** button prints round-trip deltas in mm so numerical issues surface before Stage 2 telemetry playback hits them.
- **Colour-blind palette** (`global.css`): Paul Tol "Bright" set, dual-encoded (shape + stroke width + letter labels), with dark-mode overrides.
- **Design doc** (`docs/field-map-calibration.md`) covering conventions, flow, math, data model, API, palette rationale, and Stage 2 roadmap.
- **Plan** (`docs/plans/2026-04-17-001-feat-field-map-calibration-stage-1-plan.md`) included for traceability.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- Dev server smoke-tested: `/admin/field-map-calibration` returns 200 and renders the page component with the expected CSS classes.

## Manual testing still needed (requires running RavenBrain + login)

- Click-through on the bundled 2026 field image and confirm the 1-metre grid lines up with visible field features
- Verify button shows sub-millimetre round-trip deltas
- Dark-mode + deuteranopia simulator pass
- iPhone 5 viewport check (lower priority per project constraints)

Pairs with the RavenBrain PR on the same branch (REST API + V27 migration + 11 API tests, all green).