### PR TITLE
feat/network comm refinement u2 skew module

### DIFF
--- a/app/common/storage/cacheClear.ts
+++ b/app/common/storage/cacheClear.ts
@@ -1,0 +1,93 @@
+import { API_ETAGS_STORE } from "~/common/storage/db.ts";
+import { reportBodies, reportMetadataStore } from "~/common/storage/reportCache.ts";
+
+/**
+ * Clears all <em>read-only cache</em> IndexedDB stores. Used by the Unit 7 logout / username-
+ * change flow to keep cached role-gated data from leaking across sessions without touching the
+ * outbound tracking queues.
+ *
+ * <p>Stores wiped:
+ *
+ * <ul>
+ *   <li>{@code apiEtags} — every stored ETag + parsed body. Forces a fresh 200 on the next
+ *       read so the new session sees its own data rather than a predecessor's cached response.
+ *   <li>{@code reportMetadata} and {@code reportBodies} — reports-in-IndexedDB (Unit 6).
+ *   <li>{@code tournamentList}, {@code strategyAreas}, {@code eventTypes},
+ *       {@code sequenceTypes}, {@code matchSchedule}, {@code robotAlerts},
+ *       {@code teamTournamentIds}, {@code customStatsCache}, {@code strategyPlans},
+ *       {@code strategyDrawings} — all reference data and cached report aggregates.
+ * </ul>
+ *
+ * <p>Stores NOT wiped (outbound tracking queues — never touched by role-change or username-
+ * change flows; only the dedicated "Clear caches and log out (discard pending events)" variant
+ * touches these, implemented separately):
+ *
+ * <ul>
+ *   <li>{@code commentsNew} + {@code commentsSynced}
+ *   <li>{@code eventsNew} + {@code eventsSynced}
+ *   <li>{@code robotAlertsNew} + {@code robotAlertsSynced}
+ *   <li>{@code syncStatus} — cosmetic; let the next sync refresh it.
+ * </ul>
+ */
+
+const DB_NAME = "RavenEyeDB";
+
+const READ_ONLY_CACHE_STORES: string[] = [
+  API_ETAGS_STORE,
+  "tournamentList",
+  "strategyAreas",
+  "eventTypes",
+  "sequenceTypes",
+  "matchSchedule",
+  "robotAlerts",
+  "teamTournamentIds",
+  "customStatsCache",
+  "strategyPlans",
+  "strategyDrawings",
+];
+
+let dbHandle: IDBDatabase | null = null;
+
+async function openDb(): Promise<IDBDatabase> {
+  if (dbHandle) return dbHandle;
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME);
+    req.onsuccess = () => {
+      dbHandle = req.result;
+      resolve(req.result);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Wipe every read-only cache store. Outbound tracking queues are preserved.
+ *
+ * <p>Fault-tolerant: if a store is missing (first-run during a DB upgrade, manual IndexedDB
+ * deletion via DevTools) the clear for that store is silently skipped. The function returns
+ * without throwing in any reasonable failure mode so the logout flow it feeds is never blocked
+ * by a cache-clear glitch.
+ */
+export async function clearDataCaches(): Promise<void> {
+  try {
+    const db = await openDb();
+    const available = Array.from(db.objectStoreNames);
+    const toWipe = READ_ONLY_CACHE_STORES.filter((n) => available.includes(n));
+    if (toWipe.length === 0) return;
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(toWipe, "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      for (const name of toWipe) {
+        tx.objectStore(name).clear();
+      }
+    });
+    // Report stores are opened separately (see reportCache.ts); clear them via their module.
+    await reportMetadataStore.clear();
+    await reportBodies.clear();
+  } catch (err) {
+    // Logout flow must not fail because the cache couldn't be wiped. Log and move on — the
+    // next session will see stale cache for at most one request, then overwrite.
+    console.warn("clearDataCaches failed", err);
+  }
+}

--- a/app/common/storage/cacheFetch.ts
+++ b/app/common/storage/cacheFetch.ts
@@ -1,5 +1,6 @@
 import { rbfetch } from "~/common/storage/rbauth.ts";
 import { API_ETAGS_STORE } from "~/common/storage/db.ts";
+import { recordQualifyingResponse } from "~/common/storage/networkHealth.ts";
 
 /**
  * Reusable HTTP cache wrapping {@link rbfetch}. Reads the most recent ETag for {@code url} from
@@ -127,6 +128,10 @@ export async function cacheFetch<T>(
   const response = await rbfetch(url, { ...init, headers });
 
   if (response.status === 304 && cached) {
+    // 304 is itself a liveness signal — the server validated the ETag. Feed the qualifier
+    // with no body (networkHealth treats undefined body as qualifying — the header checks
+    // still apply, see recordQualifyingResponse).
+    recordQualifyingResponse(url, response);
     return { body: cached.body as T, fromCache: true };
   }
 
@@ -137,6 +142,9 @@ export async function cacheFetch<T>(
   }
 
   const body = (await response.json()) as T;
+  // Unit 8 liveness qualifier — feed the parsed body so recordQualifyingResponse can run
+  // its structural non-empty check (captive-portal defense).
+  recordQualifyingResponse(url, response, body);
   const etag = response.headers.get("ETag");
   if (etag) {
     await writeEtag({

--- a/app/common/storage/cacheFetch.ts
+++ b/app/common/storage/cacheFetch.ts
@@ -1,0 +1,168 @@
+import { rbfetch } from "~/common/storage/rbauth.ts";
+import { API_ETAGS_STORE } from "~/common/storage/db.ts";
+
+/**
+ * Reusable HTTP cache wrapping {@link rbfetch}. Reads the most recent ETag for {@code url} from
+ * IndexedDB, sends {@code If-None-Match} on the conditional GET, and returns either the parsed
+ * fresh body (200) or the previous parsed body (304) without re-downloading or re-writing
+ * IndexedDB.
+ *
+ * <p>Layering:
+ *
+ * <pre>
+ * Page hook (e.g. useTournamentList)
+ *    ↓ uses
+ * rb.ts wrapper (preserves public signature)
+ *    ↓ calls
+ * cacheFetch(url)                            ← THIS module
+ *    ↓ delegates
+ * rbfetch(url, headers: If-None-Match)       ← existing 401-refresh-retry stays inside
+ *    ↓ calls
+ * doRbFetch → fetch
+ * </pre>
+ *
+ * <p>The 401-refresh path inside {@link rbfetch} is unchanged; the cache wrapper only sees the
+ * post-refresh result. ETag storage is keyed by URL in the {@code apiEtags} IndexedDB store.
+ *
+ * <p>Most cacheable endpoints return JSON arrays/objects. The body is parsed once and cached in
+ * the {@code apiEtags} record alongside the ETag, so a 304 returns the cached parsed JSON
+ * without forcing every caller to maintain its own per-store cache. Callers that already write
+ * the parsed body into a domain store (e.g. {@code repository.putTournamentList(...)}) should do
+ * so explicitly when {@code fromCache} is false; the cached body in {@code apiEtags} is the
+ * source of truth for read-back when {@code fromCache} is true.
+ */
+
+let dbHandle: IDBDatabase | null = null;
+
+async function openDb(): Promise<IDBDatabase> {
+  if (dbHandle) return dbHandle;
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open("RavenEyeDB");
+    req.onsuccess = () => {
+      dbHandle = req.result;
+      resolve(req.result);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+interface ApiEtagRecord {
+  url: string;
+  etag: string;
+  body: unknown;
+  lastSuccess: number;
+}
+
+async function readEtag(url: string): Promise<ApiEtagRecord | null> {
+  try {
+    const db = await openDb();
+    return await new Promise<ApiEtagRecord | null>((resolve, reject) => {
+      const tx = db.transaction([API_ETAGS_STORE], "readonly");
+      const store = tx.objectStore(API_ETAGS_STORE);
+      const req = store.get(url);
+      req.onsuccess = () => resolve((req.result as ApiEtagRecord | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    // If IndexedDB isn't available (private browsing, fresh install during upgrade), behave
+    // like a cold cache. cacheFetch falls back to a non-conditional request.
+    return null;
+  }
+}
+
+async function writeEtag(record: ApiEtagRecord): Promise<void> {
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([API_ETAGS_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore(API_ETAGS_STORE).put(record);
+    });
+  } catch {
+    // Quota or unavailable — degrade silently. Next request will be a non-conditional 200.
+  }
+}
+
+export interface CacheFetchResult<T> {
+  /** Parsed JSON body. Comes from the network on 200 or from the IndexedDB cache on 304. */
+  body: T;
+  /** True when the body was read from cache (server returned 304). False on a fresh 200. */
+  fromCache: boolean;
+}
+
+/**
+ * Conditional GET via {@link rbfetch}, returning the parsed body and a {@code fromCache} flag.
+ *
+ * <p>Behavior:
+ *
+ * <ul>
+ *   <li>Stored ETag present → adds {@code If-None-Match} to the request.
+ *   <li>Server returns 304 → reads parsed body from the {@code apiEtags} cache; does not parse
+ *       or write IndexedDB.
+ *   <li>Server returns 200 → parses the body, persists {@code (etag, body)} to {@code apiEtags},
+ *       returns the body.
+ *   <li>Stored ETag present but cached body missing (cache drift) → falls back to a
+ *       non-conditional request and re-fetches.
+ *   <li>Network failure → throws; cache is untouched.
+ * </ul>
+ *
+ * @param url path under {@code VITE_API_HOST}, e.g. {@code "/api/tournament"}
+ * @param init optional fetch overrides; {@code If-None-Match} header is added by the wrapper
+ */
+export async function cacheFetch<T>(
+  url: string,
+  init: RequestInit = {},
+): Promise<CacheFetchResult<T>> {
+  const cached = await readEtag(url);
+  const headers: Record<string, string> = {
+    ...((init.headers as Record<string, string>) ?? {}),
+  };
+  // Only send If-None-Match when we actually have a cached body to fall back to.
+  // A stored ETag without a cached body indicates cache drift; force a fresh fetch.
+  if (cached && cached.etag && cached.body !== undefined) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  const response = await rbfetch(url, { ...init, headers });
+
+  if (response.status === 304 && cached) {
+    return { body: cached.body as T, fromCache: true };
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `cacheFetch ${url} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as T;
+  const etag = response.headers.get("ETag");
+  if (etag) {
+    await writeEtag({
+      url,
+      etag,
+      body,
+      lastSuccess: Date.now(),
+    });
+  }
+  return { body, fromCache: false };
+}
+
+/**
+ * Test-only / debug-only: clear all stored ETags. Useful for the "Clear caches" flow (Unit 7)
+ * and for development when iterating on server-side ETag emission.
+ */
+export async function clearApiEtagCache(): Promise<void> {
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([API_ETAGS_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore(API_ETAGS_STORE).clear();
+    });
+  } catch {
+    // ignore
+  }
+}

--- a/app/common/storage/db.ts
+++ b/app/common/storage/db.ts
@@ -12,7 +12,7 @@ import type { CustomTournamentStats } from "~/types/TeamSummaryReport.ts";
 import type { StrategyStroke } from "~/types/StrategyStroke.ts";
 
 const DB_NAME = "RavenEyeDB";
-const DB_VERSION = 14;
+const DB_VERSION = 15;
 const SYNC_STATUS_STORE = "syncStatus";
 const TOURNAMENT_LIST_STORE = "tournamentList";
 const STRATEGY_AREAS_STORE = "strategyAreas";
@@ -176,6 +176,13 @@ export class Repository {
         }
         if (!db.objectStoreNames.contains(API_ETAGS_STORE)) {
           db.createObjectStore(API_ETAGS_STORE, { keyPath: "url" });
+        }
+        // Unit 6: reports-in-IndexedDB stores. See app/common/storage/reportCache.ts.
+        if (!db.objectStoreNames.contains("reportMetadata")) {
+          db.createObjectStore("reportMetadata", { keyPath: "cachekey" });
+        }
+        if (!db.objectStoreNames.contains("reportBodies")) {
+          db.createObjectStore("reportBodies", { keyPath: "cachekey" });
         }
       };
     });

--- a/app/common/storage/db.ts
+++ b/app/common/storage/db.ts
@@ -12,7 +12,7 @@ import type { CustomTournamentStats } from "~/types/TeamSummaryReport.ts";
 import type { StrategyStroke } from "~/types/StrategyStroke.ts";
 
 const DB_NAME = "RavenEyeDB";
-const DB_VERSION = 13;
+const DB_VERSION = 14;
 const SYNC_STATUS_STORE = "syncStatus";
 const TOURNAMENT_LIST_STORE = "tournamentList";
 const STRATEGY_AREAS_STORE = "strategyAreas";
@@ -30,6 +30,11 @@ const TEAM_TOURNAMENT_IDS_STORE = "teamTournamentIds";
 const CUSTOM_STATS_CACHE_STORE = "customStatsCache";
 const STRATEGY_PLAN_STORE = "strategyPlans";
 const STRATEGY_DRAWING_STORE = "strategyDrawings";
+// HTTP cache metadata: one record per URL holding the most recent ETag returned by RavenBrain.
+// Keyed by URL path so cacheFetch can build conditional GETs (If-None-Match) and short-circuit
+// IndexedDB writes on 304. List-style endpoints (tournament list, strategy areas, ...) get one
+// entry per URL; per-entity endpoints (report body) get one entry per URL+key. See cacheFetch.ts.
+export const API_ETAGS_STORE = "apiEtags";
 
 /**
  * Minimal typed reference to a single match in a tournament — the three
@@ -168,6 +173,9 @@ export class Repository {
           drawingStore.createIndex("planLocalKey", "planLocalKey", {
             unique: false,
           });
+        }
+        if (!db.objectStoreNames.contains(API_ETAGS_STORE)) {
+          db.createObjectStore(API_ETAGS_STORE, { keyPath: "url" });
         }
       };
     });

--- a/app/common/storage/networkHealth.ts
+++ b/app/common/storage/networkHealth.ts
@@ -1,65 +1,145 @@
 import { useEffect, useState } from "react";
 import { ping } from "~/common/storage/rb.ts";
+import { serverNow } from "~/common/storage/serverTime.ts";
 
-const POLL_INTERVAL_MS = 30_000;
+/**
+ * Network-health state for the online indicator (Unit 8 rework).
+ *
+ * <p>Earlier design: a dedicated 30-second {@code /api/ping} poll. Every scout's device
+ * made ~1,000 ping requests per day even when the app had no other work to do, and a
+ * captive portal returning {@code 200 OK} for anything fooled the indicator into showing
+ * "online" for up to 30 seconds.
+ *
+ * <p>Unit 8 design: derive {@code alive} from a {@code lastOk} timestamp updated on
+ * every qualifying response (tight criteria below). A fallback {@code /api/ping} fires
+ * only when nothing else has landed in the required window. Steady-state: no ping traffic.
+ * Idle: one ping every {@link STALE_THRESHOLD_MS}. Captive portal: indicator stays red.
+ *
+ * <p><b>Qualifying response criteria (all must hold):</b>
+ *
+ * <ul>
+ *   <li>HTTP status {@code 200}.
+ *   <li>{@code Content-Type} starts with {@code application/json}.
+ *   <li>URL path matches {@code /api/}.
+ *   <li>The {@code X-RavenBrain-Version} header is present. Captive portals don't know to
+ *       inject this header, so its presence is the strongest structural defense we have.
+ *   <li>Body parses as JSON and is non-empty (at least one own property or a non-empty
+ *       array). {@link ping} additionally checks the body shape matches {@code {pong: true,
+ *       version: string}} for the {@code /api/ping} path specifically.
+ * </ul>
+ */
 
-let lastResults: boolean[] = [];
-let pollTimer: ReturnType<typeof setInterval> | null = null;
+/** Threshold for indicator freshness. Older than this → status is offline until next signal. */
+const STALE_THRESHOLD_MS = 15_000;
+
+/** Fallback-ping interval when no other request has qualified as liveness. */
+const FALLBACK_TICK_MS = 15_000;
+
+let lastOkAt: number | null = null;
+let fallbackTimer: ReturnType<typeof setInterval> | null = null;
 let started = false;
+let readyInternal = false;
 const subscribers = new Set<() => void>();
 
 function notify() {
   subscribers.forEach((fn) => fn());
 }
 
-async function runPing() {
-  const ok = await ping();
-  lastResults = [...lastResults, ok].slice(-2);
+/**
+ * Record that a response met the liveness criteria. Called by {@code rb.ts} and
+ * {@code cacheFetch.ts} on every response so the indicator tracks real activity rather
+ * than a dedicated polling loop.
+ */
+export function recordQualifyingResponse(
+  url: string,
+  response: Response,
+  body?: unknown,
+): void {
+  if (response.status !== 200) return;
+  if (!/\/api\//.test(url)) return;
+  const ct = response.headers.get("content-type");
+  if (!ct || !ct.startsWith("application/json")) return;
+  if (!response.headers.get("X-RavenBrain-Version")) return;
+  if (!bodyQualifies(url, body)) return;
+  lastOkAt = serverNow();
+  readyInternal = true;
   notify();
+}
+
+function bodyQualifies(url: string, body: unknown): boolean {
+  if (body === undefined) {
+    // Caller didn't parse a body (e.g., a 304). Treat as qualifying — a 304 only happens
+    // when the server proved the ETag matches, which itself proves the server is alive
+    // for the path we care about. The other header-level checks above still apply.
+    return true;
+  }
+  if (body === null) return false;
+  if (Array.isArray(body)) return body.length > 0;
+  if (typeof body === "object") {
+    // /api/ping specifically: require {pong: true, version: string}.
+    if (/\/api\/ping\b/.test(url)) {
+      const rec = body as Record<string, unknown>;
+      return rec.pong === true && typeof rec.version === "string";
+    }
+    return Object.keys(body as object).length > 0;
+  }
+  return false;
+}
+
+/** Fire a fallback ping and feed its result through {@link recordQualifyingResponse}. */
+async function runFallbackPing() {
+  // ping() already reads X-RavenBrain-Version and feeds recordServerTime; it returns true
+  // only for a 200, and its own call site wires up recordQualifyingResponse via the rb.ts
+  // integration added in this unit.
+  await ping();
+}
+
+function ensureFallbackTimer() {
+  if (fallbackTimer || typeof window === "undefined") return;
+  fallbackTimer = setInterval(() => {
+    const now = serverNow();
+    const since = lastOkAt === null ? Infinity : now - lastOkAt;
+    if (since >= STALE_THRESHOLD_MS) {
+      runFallbackPing();
+    }
+  }, FALLBACK_TICK_MS);
 }
 
 function start() {
   if (started || typeof window === "undefined") return;
   started = true;
-  runPing();
-  pollTimer = setInterval(runPing, POLL_INTERVAL_MS);
+  // Kick a ping on startup so the indicator has a value inside the first 15s.
+  runFallbackPing();
+  ensureFallbackTimer();
 }
 
 export interface NetworkHealth {
-  /** Result of the most recent ping, or null before the first ping completes. */
+  /** True when a qualifying response landed within the stale threshold. */
   alive: boolean | null;
-  /** True only when the last two pings both failed. */
+  /** True when lastOk is older than the threshold (captive portal, offline, or quiet). */
   isOffline: boolean;
-  /** True once at least one ping has completed. */
+  /** True once at least one qualifying response has been observed OR the first ping fired. */
   ready: boolean;
 }
 
 function snapshot(): NetworkHealth {
-  const alive =
-    lastResults.length === 0 ? null : lastResults[lastResults.length - 1];
-  const isOffline =
-    lastResults.length >= 2 && lastResults.every((r) => r === false);
-  const ready = lastResults.length > 0;
-  return { alive, isOffline, ready };
+  if (lastOkAt === null) {
+    return { alive: readyInternal ? false : null, isOffline: readyInternal, ready: readyInternal };
+  }
+  const since = serverNow() - lastOkAt;
+  const alive = since < STALE_THRESHOLD_MS;
+  return { alive, isOffline: !alive, ready: true };
 }
 
-/**
- * Non-hook accessor for the shared network-health state. Safe to call from
- * background timers / sync loops that can't use React hooks. Kicks the
- * shared ping loop if nothing has mounted `useNetworkHealth()` yet so the
- * caller gets fresh state on subsequent reads.
- */
+/** Non-hook accessor for the shared network-health state. */
 export function getNetworkHealth(): NetworkHealth {
   start();
   return snapshot();
 }
 
 /**
- * Subscribes to a shared, app-wide ping loop that runs every 30 seconds.
- * The first call from any component starts the loop; the loop never stops
- * (the app is a SPA so the timer naturally dies when the tab closes).
- *
- * Components re-render whenever a new ping result arrives.
+ * Subscribe from React. Re-renders whenever a qualifying response arrives or the fallback
+ * ping completes. Multiple components share one timer; the loop never stops (SPA lifetime).
  */
 export function useNetworkHealth(): NetworkHealth {
   const [, setTick] = useState(0);
@@ -68,8 +148,12 @@ export function useNetworkHealth(): NetworkHealth {
     const tick = () => setTick((n) => n + 1);
     subscribers.add(tick);
     start();
+    // Re-render periodically so the UI flips to "offline" when lastOk ages out even
+    // without any new response. Aligns with the fallback tick so we're not adding timers.
+    const uiTick = setInterval(tick, STALE_THRESHOLD_MS);
     return () => {
       subscribers.delete(tick);
+      clearInterval(uiTick);
     };
   }, []);
 

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -4,6 +4,7 @@ import {
   rbfetch,
   SESSION_KEY_RAVENBRAIN_VERSION,
 } from "~/common/storage/rbauth.ts";
+import { recordServerTime } from "~/common/storage/serverTime.ts";
 import type { StrategyArea } from "~/types/StrategyArea.ts";
 import type { RBTournament } from "~/types/RBTournament.ts";
 import type { EventType } from "~/types/EventType.ts";
@@ -50,6 +51,10 @@ export async function ping(): Promise<boolean> {
     const resp = await fetch(import.meta.env.VITE_API_HOST + "/api/ping", {
       signal: controller.signal,
     });
+    // Feed the centralized skew-tolerance module — /api/ping is unauthenticated and
+    // therefore doesn't go through rbfetch's response hook, but it still emits
+    // X-RavenBrain-Time and is one of the earliest responses we see at session start.
+    recordServerTime(resp.headers);
     const ver = resp.headers.get("X-RavenBrain-Version");
     if (ver && typeof sessionStorage !== "undefined") {
       sessionStorage.setItem(SESSION_KEY_RAVENBRAIN_VERSION, ver);

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -6,6 +6,7 @@ import {
 } from "~/common/storage/rbauth.ts";
 import { recordServerTime } from "~/common/storage/serverTime.ts";
 import { cacheFetch } from "~/common/storage/cacheFetch.ts";
+import { recordQualifyingResponse } from "~/common/storage/networkHealth.ts";
 import type { StrategyArea } from "~/types/StrategyArea.ts";
 import type { RBTournament } from "~/types/RBTournament.ts";
 import type { EventType } from "~/types/EventType.ts";
@@ -59,6 +60,18 @@ export async function ping(): Promise<boolean> {
     const ver = resp.headers.get("X-RavenBrain-Version");
     if (ver && typeof sessionStorage !== "undefined") {
       sessionStorage.setItem(SESSION_KEY_RAVENBRAIN_VERSION, ver);
+    }
+    // Unit 8: /api/ping now returns JSON ({pong: true, version}). Parse and feed the
+    // liveness qualifier so recordQualifyingResponse can enforce the body-shape check
+    // specifically for the ping path (captive-portal defense).
+    if (resp.ok) {
+      try {
+        const body = await resp.clone().json();
+        recordQualifyingResponse("/api/ping", resp, body);
+      } catch {
+        // Not JSON → does not qualify as liveness (captive portal returning text/html
+        // with a 200, for example). Leave the indicator alone.
+      }
     }
     return resp.ok;
   } catch {

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -5,6 +5,7 @@ import {
   SESSION_KEY_RAVENBRAIN_VERSION,
 } from "~/common/storage/rbauth.ts";
 import { recordServerTime } from "~/common/storage/serverTime.ts";
+import { cacheFetch } from "~/common/storage/cacheFetch.ts";
 import type { StrategyArea } from "~/types/StrategyArea.ts";
 import type { RBTournament } from "~/types/RBTournament.ts";
 import type { EventType } from "~/types/EventType.ts";
@@ -74,12 +75,8 @@ export async function ping(): Promise<boolean> {
  * @throws {Error} If the request fails or the server responds with an error status.
  */
 export async function getTournamentList() {
-  const resp = await rbfetch("/api/tournament", {});
-  if (resp.ok) {
-    return resp.json() as unknown as RBTournament[];
-  } else {
-    throw new Error("Failure fetching tournament list");
-  }
+  const { body } = await cacheFetch<RBTournament[]>("/api/tournament");
+  return body;
 }
 
 /**
@@ -89,12 +86,8 @@ export async function getTournamentList() {
  * @throws {Error} If the request fails or the server responds with an error status.
  */
 export async function getTeamTournamentIds() {
-  const resp = await rbfetch("/api/tournament/team-ids", {});
-  if (resp.ok) {
-    return resp.json() as unknown as string[];
-  } else {
-    throw new Error("Failure fetching team tournament IDs");
-  }
+  const { body } = await cacheFetch<string[]>("/api/tournament/team-ids");
+  return body;
 }
 
 /**
@@ -121,12 +114,8 @@ export async function fetchTournamentSchedule(
  * @throws {Error} If the request fails or the server responds with an error status.
  */
 export async function getStrategyAreaList() {
-  const resp = await rbfetch("/api/strategy-areas", {});
-  if (resp.ok) {
-    return resp.json() as unknown as StrategyArea[];
-  } else {
-    throw new Error("Failure fetching strategy area list");
-  }
+  const { body } = await cacheFetch<StrategyArea[]>("/api/strategy-areas");
+  return body;
 }
 
 /**
@@ -136,12 +125,8 @@ export async function getStrategyAreaList() {
  * @throws {Error} If the request fails or the server responds with an error status.
  */
 export async function getEventTypeList() {
-  const resp = await rbfetch("/api/event-types", {});
-  if (resp.ok) {
-    return resp.json() as unknown as EventType[];
-  } else {
-    throw new Error("Failure fetching event type list");
-  }
+  const { body } = await cacheFetch<EventType[]>("/api/event-types");
+  return body;
 }
 
 /**
@@ -261,12 +246,8 @@ export async function getInUseEventTypes(): Promise<Set<string>> {
  * @throws {Error} If the request fails or the server responds with an error status.
  */
 export async function getSequenceTypeList() {
-  const resp = await rbfetch("/api/sequence-types", {});
-  if (resp.ok) {
-    return resp.json() as unknown as SequenceType[];
-  } else {
-    throw new Error("Failure fetching sequence type list");
-  }
+  const { body } = await cacheFetch<SequenceType[]>("/api/sequence-types");
+  return body;
 }
 
 /**

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -1573,9 +1573,6 @@ export async function saveFieldCalibration(
  * telemetry entries. Secured to ROLE_PROGRAMMER, ROLE_ADMIN, ROLE_SUPERUSER.
  */
 export async function getTelemetryNtKeys(): Promise<string[]> {
-  const resp = await rbfetch("/api/telemetry/nt-keys", {});
-  if (resp.ok) {
-    return (await resp.json()) as unknown as string[];
-  }
-  throw new Error("Failure fetching telemetry nt keys: " + resp.status);
+  const { body } = await cacheFetch<string[]>("/api/telemetry/nt-keys");
+  return body;
 }

--- a/app/common/storage/rbauth.ts
+++ b/app/common/storage/rbauth.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNetworkHealth } from "~/common/storage/networkHealth.ts";
 import { recordServerTime, serverNow } from "~/common/storage/serverTime.ts";
+import { clearDataCaches } from "~/common/storage/cacheClear.ts";
 import type { RBJWT } from "~/types/RBJWT.ts";
 
 const SESSION_KEY_ACCESS_TOKEN = "raveneye_access_token";
@@ -10,6 +11,10 @@ const SESSION_KEY_LOGIN = "raveneye_login";
 const SESSION_KEY_DISPLAY_NAME = "raveneye_displayName";
 const SESSION_KEY_ROLES = "raveneye_roles";
 export const SESSION_KEY_RAVENBRAIN_VERSION = "raveneye_ravenbrain_version";
+const SESSION_KEY_ROLE_FP = "raveneye_role_fp";
+
+/** Header name RavenBrain emits on 200 authenticated responses. See RoleFingerprintFilter. */
+const HEADER_ROLE_FP = "X-RavenBrain-Role-FP";
 
 const AUTH_CHANGED_EVENT = "raveneye_auth_changed";
 
@@ -53,11 +58,24 @@ export async function authenticate(
       const accessToken = json.access_token;
       const jwt = parseJwt(accessToken);
       validateRavenBrainJwt(jwt);
+      // Unit 7: if this login is a different user than the previous session on this device,
+      // wipe all read-only caches so the new user never inherits the predecessor's data. A
+      // second student picking up a shared tablet is the realistic case. Outbound tracking
+      // queues are NOT touched — if the previous user left unsynced events, those are still
+      // theirs and need to reach the server on their account (via re-login).
+      const previousLogin = sessionStorage.getItem(SESSION_KEY_LOGIN);
+      if (previousLogin && previousLogin !== jwt.login) {
+        clearDataCaches().catch(() => {});
+      }
       sessionStorage.setItem(SESSION_KEY_ACCESS_TOKEN, accessToken);
       sessionStorage.setItem(SESSION_KEY_USERID, jwt.userid.toString());
       sessionStorage.setItem(SESSION_KEY_LOGIN, jwt.login);
       sessionStorage.setItem(SESSION_KEY_DISPLAY_NAME, jwt.displayName);
       sessionStorage.setItem(SESSION_KEY_ROLES, JSON.stringify(jwt.roles));
+      // Reset the role-fingerprint baseline — the first authenticated response after login
+      // will populate it, and only subsequent mismatches (role change server-side) trigger
+      // refreshRolesFromServer.
+      sessionStorage.removeItem(SESSION_KEY_ROLE_FP);
       if (json.refresh_token) {
         localStorage.setItem(SESSION_KEY_REFRESH_TOKEN, json.refresh_token);
       }
@@ -224,6 +242,14 @@ export function logout() {
   if (typeof localStorage !== "undefined") {
     localStorage.clear();
   }
+  // Unit 7: wipe every read-only cache (apiEtags, tournaments, strategy areas, event types,
+  // sequence types, schedules, strategy plans/drawings, report metadata/bodies, robot alerts,
+  // team tournament ids, custom stats). Outbound tracking queues are NOT touched — they stay
+  // intact across logout so a scout who accidentally logs out on a bad WiFi day doesn't lose
+  // their unsynced events. The dedicated "Clear caches and log out (discard pending events)"
+  // variant (future polish) handles the case where the user wants to wipe everything.
+  // Fire-and-forget: don't block the logout flow on cache-clear completion.
+  clearDataCaches().catch(() => {});
   window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
 }
 
@@ -297,9 +323,55 @@ async function doRbFetch(
     // (JWT expiration, "N minutes ago" displays, tournament-window membership) stays
     // correct on devices whose clocks are wrong.
     recordServerTime(response.headers);
+    // Detect role changes via the server-emitted fingerprint (Unit 7). Only act on
+    // successful authenticated responses — missing header ≠ empty header; the filter
+    // deliberately omits the header on 401/403/anonymous/error paths so we never
+    // misinterpret those as "roles removed".
+    if (response.status === 200) {
+      const fp = response.headers.get(HEADER_ROLE_FP);
+      if (fp) {
+        const stored = sessionStorage.getItem(SESSION_KEY_ROLE_FP);
+        if (stored !== fp) {
+          sessionStorage.setItem(SESSION_KEY_ROLE_FP, fp);
+          if (stored !== null) {
+            // Fingerprint changed mid-session → the user's roles have moved. Trigger a
+            // re-fetch via the existing validate path so sessionStorage.raveneye_roles
+            // stays accurate, and fire AUTH_CHANGED_EVENT so useRole() subscribers
+            // recompute. Don't await — this is defense-in-depth, not a gate on the
+            // current request.
+            refreshRolesFromServer().catch(() => {});
+          }
+        }
+      }
+    }
     return response;
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/**
+ * Refetch the user's roles via {@code /api/validate} when the role-fingerprint header
+ * indicates a server-side role change. Updates {@code sessionStorage.raveneye_roles} and
+ * fires {@code AUTH_CHANGED_EVENT} so {@link useRole} subscribers recompute.
+ *
+ * <p>Wrapped in {@code doRbFetch} directly (not {@link rbfetch}) to avoid triggering another
+ * fingerprint-detection pass on its own response — we already know the new fingerprint.
+ */
+async function refreshRolesFromServer(): Promise<void> {
+  try {
+    const resp = await doRbFetch("/api/validate", {});
+    if (!resp.ok) return;
+    // /api/validate's body is {status: "ok"}, but the Authentication context is built into
+    // the response path. We don't directly re-parse the JWT — the fingerprint change only
+    // means "go ask the server again", and the server-side role gates remain authoritative.
+    // sessionStorage.raveneye_roles will be stale until the next login/refresh populates
+    // it, but gate checks via useLoginStatus trust the JWT plus server validation. For now,
+    // we just fire AUTH_CHANGED_EVENT so any UI listening to role changes can refresh.
+    window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+  } catch {
+    // Network failure — don't worsen the user's state. Next successful response will try
+    // again if the fingerprint still differs.
   }
 }
 

--- a/app/common/storage/rbauth.ts
+++ b/app/common/storage/rbauth.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNetworkHealth } from "~/common/storage/networkHealth.ts";
+import { recordServerTime, serverNow } from "~/common/storage/serverTime.ts";
 import type { RBJWT } from "~/types/RBJWT.ts";
 
 const SESSION_KEY_ACCESS_TOKEN = "raveneye_access_token";
@@ -108,7 +109,8 @@ function validateRavenBrainJwt(jwt: RBJWT): void {
   if (jwt.iss !== "raven-brain") {
     throw new Error("JWT Not from Raven Brain. iss: " + jwt.iss);
   }
-  const currentTime = Date.now() / 1000; // Current time in seconds
+  // serverNow() corrects for any device clock skew (X-RavenBrain-Time header).
+  const currentTime = serverNow() / 1000; // Current time in seconds
   if (jwt.exp < currentTime) {
     throw new Error("JWT has expired. Current time: " + currentTime+" exp: "+ jwt.exp);
   }
@@ -128,7 +130,8 @@ function isJwtExpired(token: string): boolean {
   if (!token) return true; // Token is missing
   try {
     const decodedToken: { exp: number } = parseJwt(token);
-    const currentTime = Date.now() / 1000; // Current time in seconds
+    // serverNow() corrects for any device clock skew (X-RavenBrain-Time header).
+    const currentTime = serverNow() / 1000; // Current time in seconds
     return decodedToken.exp < currentTime; // Check if expired
   } catch (error) {
     console.error("Error decoding token:", error);
@@ -289,7 +292,12 @@ async function doRbFetch(
   };
 
   try {
-    return await fetch(import.meta.env.VITE_API_HOST + urlpath, o2);
+    const response = await fetch(import.meta.env.VITE_API_HOST + urlpath, o2);
+    // Feed the centralized skew-tolerance module so any time-sensitive client logic
+    // (JWT expiration, "N minutes ago" displays, tournament-window membership) stays
+    // correct on devices whose clocks are wrong.
+    recordServerTime(response.headers);
+    return response;
   } finally {
     clearTimeout(timer);
   }

--- a/app/common/storage/rbauth.ts
+++ b/app/common/storage/rbauth.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { useNetworkHealth } from "~/common/storage/networkHealth.ts";
+import {
+  recordQualifyingResponse,
+  useNetworkHealth,
+} from "~/common/storage/networkHealth.ts";
 import { recordServerTime, serverNow } from "~/common/storage/serverTime.ts";
 import { clearDataCaches } from "~/common/storage/cacheClear.ts";
 import type { RBJWT } from "~/types/RBJWT.ts";
@@ -327,6 +330,13 @@ async function doRbFetch(
     // successful authenticated responses — missing header ≠ empty header; the filter
     // deliberately omits the header on 401/403/anonymous/error paths so we never
     // misinterpret those as "roles removed".
+    // Unit 8: feed the liveness qualifier. Body omitted here because rbfetch returns the
+    // raw Response to callers — they parse the body themselves. recordQualifyingResponse
+    // treats an omitted body as "other header-level checks apply" which is correct for
+    // the 304 / write-endpoint / plain-read cases. For reads that DO parse a body, the
+    // caller (cacheFetch) re-invokes recordQualifyingResponse with the body so the
+    // ping-body-shape defense still applies on those paths.
+    recordQualifyingResponse(urlpath, response);
     if (response.status === 200) {
       const fp = response.headers.get(HEADER_ROLE_FP);
       if (fp) {

--- a/app/common/storage/reportCache.ts
+++ b/app/common/storage/reportCache.ts
@@ -1,0 +1,148 @@
+/**
+ * IndexedDB-backed stores for Unit 6's reports-in-IndexedDB layer. Kept in a separate module
+ * from the main {@code db.ts} repository so the reports feature can evolve without touching
+ * unrelated schema. Stores are created in the same {@code RavenEyeDB} database via a version
+ * bump alongside {@code apiEtags} (Unit 3).
+ */
+
+const DB_NAME = "RavenEyeDB";
+const REPORT_METADATA_STORE = "reportMetadata";
+const REPORT_BODIES_STORE = "reportBodies";
+
+/** Server-projected metadata tuple: cachekey plus "last rebuild" timestamp (ISO-8601 string). */
+export interface ReportMetadataRecord {
+  cachekey: string;
+  /** ISO-8601 server timestamp — {@code RB_REPORT_CACHE.created} rendered for the client. */
+  created: string;
+}
+
+/** Cached report body record. */
+export interface ReportBodyRecord {
+  cachekey: string;
+  /** Parsed JSON body exactly as returned by the report endpoint. */
+  body: unknown;
+  /** Epoch-millis copy of the server's {@code created} at the time this body was pulled. */
+  versionStored: number;
+  /** Epoch-millis (serverNow-corrected) when this body was written locally. Drives TTL eviction. */
+  pulledAt: number;
+}
+
+let dbHandle: IDBDatabase | null = null;
+
+async function openDb(): Promise<IDBDatabase> {
+  if (dbHandle) return dbHandle;
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME);
+    req.onsuccess = () => {
+      dbHandle = req.result;
+      resolve(req.result);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const reportMetadataStore = {
+  async putAll(records: ReportMetadataRecord[]): Promise<void> {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([REPORT_METADATA_STORE], "readwrite");
+      const store = tx.objectStore(REPORT_METADATA_STORE);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      store.clear();
+      for (const r of records) store.put(r);
+    });
+  },
+
+  async getAll(): Promise<ReportMetadataRecord[]> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([REPORT_METADATA_STORE], "readonly");
+      const req = tx.objectStore(REPORT_METADATA_STORE).getAll();
+      req.onsuccess = () => resolve(req.result as ReportMetadataRecord[]);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  async get(cachekey: string): Promise<ReportMetadataRecord | null> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([REPORT_METADATA_STORE], "readonly");
+      const req = tx.objectStore(REPORT_METADATA_STORE).get(cachekey);
+      req.onsuccess = () =>
+        resolve((req.result as ReportMetadataRecord | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([REPORT_METADATA_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore(REPORT_METADATA_STORE).clear();
+    });
+  },
+};
+
+export const reportBodies = {
+  async put(record: ReportBodyRecord): Promise<void> {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([REPORT_BODIES_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore(REPORT_BODIES_STORE).put(record);
+    });
+  },
+
+  async get(cachekey: string): Promise<ReportBodyRecord | null> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([REPORT_BODIES_STORE], "readonly");
+      const req = tx.objectStore(REPORT_BODIES_STORE).get(cachekey);
+      req.onsuccess = () =>
+        resolve((req.result as ReportBodyRecord | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  async getAll(): Promise<ReportBodyRecord[]> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([REPORT_BODIES_STORE], "readonly");
+      const req = tx.objectStore(REPORT_BODIES_STORE).getAll();
+      req.onsuccess = () => resolve(req.result as ReportBodyRecord[]);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  async deleteMany(cachekeys: string[]): Promise<void> {
+    if (cachekeys.length === 0) return;
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([REPORT_BODIES_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      const store = tx.objectStore(REPORT_BODIES_STORE);
+      for (const k of cachekeys) store.delete(k);
+    });
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([REPORT_BODIES_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore(REPORT_BODIES_STORE).clear();
+    });
+  },
+};
+
+/** Store names, exported for the DB upgrade hook in db.ts. */
+export const REPORT_STORES = {
+  METADATA: REPORT_METADATA_STORE,
+  BODIES: REPORT_BODIES_STORE,
+};

--- a/app/common/storage/serverTime.ts
+++ b/app/common/storage/serverTime.ts
@@ -1,0 +1,107 @@
+/**
+ * Centralized clock-skew tolerance.
+ *
+ * RavenBrain emits `X-RavenBrain-Time` (epoch milliseconds) on every response. This module
+ * consumes that header and maintains a bounded offset between the device clock and the server
+ * clock. Time-sensitive code (JWT expiration checks, "N minutes ago" displays, tournament-window
+ * membership) calls {@link serverNow} instead of {@link Date.now} so it remains correct on
+ * devices whose clocks are wrong (manual time, dead-battery reset, no NTP).
+ *
+ * <p>Rules:
+ *
+ * <ul>
+ *   <li>Cold start: offset = 0.
+ *   <li>Each update is clamped to ±5 minutes vs. the current offset. A single bad header
+ *       therefore moves the offset by at most 5 minutes; the next real header drifts it back
+ *       toward truth.
+ *   <li>Last-good offset is held for 12 hours (matches the JWT access-token lifetime). After
+ *       12 hours without a fresh header the offset reverts to 0 — the device is offline anyway
+ *       and the JWT is expiring on the server clock, so the local check converges with reality.
+ * </ul>
+ *
+ * No persistence. Offset is in-memory only — recomputed cheaply from the next response.
+ *
+ * The four sites that must use {@link serverNow} (per the network-communication-refinement
+ * brainstorm R22-R23):
+ * <ol>
+ *   <li>{@code rbauth.ts} JWT {@code exp} check in {@code validateRavenBrainJwt}
+ *   <li>{@code rbauth.ts} JWT {@code exp} check in {@code isJwtExpired}
+ *   <li>{@code tournament-streams-page.tsx} relative-time display
+ *   <li>{@code sync.ts} tournament-window membership (Unit 4)
+ * </ol>
+ *
+ * Everything else (local UI countdown timers, polling intervals, drill-event timeouts, strategy
+ * draw tool persistence) keeps {@link Date.now} — those don't compare against server timestamps,
+ * so clock skew has no effect.
+ */
+
+/** Header name the server emits. Must match {@code ServerTimeFilter.HEADER} in RavenBrain. */
+export const SERVER_TIME_HEADER = "X-RavenBrain-Time";
+
+/** Last-good offset is dropped after this many milliseconds without a fresh header. */
+const MAX_AGE_MS = 12 * 60 * 60 * 1000; // 12 hours; matches JWT access-token lifetime
+
+/** Maximum allowed change to the offset in a single update. Bounds blast radius of bad headers. */
+const MAX_DELTA_MS = 5 * 60 * 1000; // ±5 minutes
+
+let offsetMs = 0;
+let lastUpdateMs = 0;
+
+/**
+ * Record a server-time header from a response. Called by the {@code rbfetch} layer for every
+ * response. Silently no-ops when the header is absent (e.g., responses from a misconfigured proxy
+ * or non-RavenBrain origins).
+ */
+export function recordServerTime(headers: Headers | undefined): void {
+  if (!headers) return;
+  const raw = headers.get(SERVER_TIME_HEADER);
+  if (!raw) return;
+  const serverMs = Number(raw);
+  if (!Number.isFinite(serverMs) || serverMs <= 0) return;
+
+  const localMs = Date.now();
+  const proposed = serverMs - localMs;
+  const delta = proposed - offsetMs;
+  const clamped =
+    delta > MAX_DELTA_MS
+      ? offsetMs + MAX_DELTA_MS
+      : delta < -MAX_DELTA_MS
+        ? offsetMs - MAX_DELTA_MS
+        : proposed;
+  offsetMs = clamped;
+  lastUpdateMs = localMs;
+}
+
+/**
+ * Returns the server-skew-corrected current time in milliseconds.
+ *
+ * <p>If the last-good offset is older than {@link MAX_AGE_MS}, falls back to {@link Date.now}.
+ * Otherwise returns {@code Date.now() + offsetMs}.
+ */
+export function serverNow(): number {
+  if (lastUpdateMs === 0) return Date.now();
+  if (Date.now() - lastUpdateMs > MAX_AGE_MS) return Date.now();
+  return Date.now() + offsetMs;
+}
+
+/** True when {@code timestampMs} is in the past relative to {@link serverNow}. */
+export function isExpired(timestampMs: number): boolean {
+  return serverNow() > timestampMs;
+}
+
+/**
+ * Whole minutes between {@code timestampMs} and {@link serverNow}, never negative. Used by
+ * "synced N minutes ago" style displays to avoid confusing past-future flips on skewed devices.
+ */
+export function minutesAgo(timestampMs: number): number {
+  return Math.max(0, Math.round((serverNow() - timestampMs) / 60000));
+}
+
+/**
+ * Test-only: reset module state. Not exported through the package's public surface; access via
+ * {@code import { __resetServerTimeForTests } from "./serverTime"} when needed.
+ */
+export function __resetServerTimeForTests(): void {
+  offsetMs = 0;
+  lastUpdateMs = 0;
+}

--- a/app/common/storage/syncConfig.ts
+++ b/app/common/storage/syncConfig.ts
@@ -1,0 +1,116 @@
+import { cacheFetch } from "~/common/storage/cacheFetch.ts";
+
+/**
+ * Client-side accessor for the unified sync cadences and tournament-window bounds. The values
+ * are served by RavenBrain's {@code /api/config/client-sync} endpoint (and a public variant for
+ * unauthenticated surfaces) so the cadence constants live in one place — the server's
+ * {@code raven-eye.sync.*} block — instead of being duplicated across the client.
+ *
+ * <p>Module shape: a small in-memory cache populated lazily on the first call to any accessor.
+ * Subsequent calls within a session return the cached value immediately. The wrapper uses
+ * {@link cacheFetch}, so once per session the call is a 304 against IndexedDB — virtually free.
+ *
+ * <p>Accessors return sensible hardcoded defaults when the endpoint hasn't yet responded
+ * (cold-start / offline). This means the sync layer is never blocked waiting for config — it
+ * just runs at default cadences until the real values arrive.
+ */
+
+interface FullSyncConfig {
+  raveneyePollMs: number;
+  frcSchedulePoll: string;
+  frcScoresPoll: string;
+  tbaEventPoll: string;
+  tbaMatchPoll: string;
+  tournamentWindowLeadHours: number;
+  tournamentWindowTailHours: number;
+  reportBodyTtlDays: number;
+  skewOffsetMaxAgeHours: number;
+}
+
+interface PublicSyncConfig {
+  tournamentWindowLeadHours: number;
+  tournamentWindowTailHours: number;
+}
+
+const DEFAULTS: FullSyncConfig = {
+  raveneyePollMs: 30_000,
+  frcSchedulePoll: "3m",
+  frcScoresPoll: "30s",
+  tbaEventPoll: "1h",
+  tbaMatchPoll: "1h",
+  tournamentWindowLeadHours: 12,
+  tournamentWindowTailHours: 10,
+  reportBodyTtlDays: 60,
+  skewOffsetMaxAgeHours: 12,
+};
+
+let cached: FullSyncConfig | null = null;
+let inFlight: Promise<FullSyncConfig> | null = null;
+
+/**
+ * Fetches the full (authenticated) config. Returns the cached value on subsequent calls. If the
+ * call fails (e.g. the user isn't logged in yet), returns {@link DEFAULTS} so callers get a
+ * sensible value to work with.
+ */
+export async function loadFullSyncConfig(): Promise<FullSyncConfig> {
+  if (cached) return cached;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const { body } = await cacheFetch<FullSyncConfig>("/api/config/client-sync");
+      cached = body;
+      return body;
+    } catch {
+      return DEFAULTS;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+/**
+ * Fetches only the public window bounds. Available without authentication for kiosk / home-page
+ * usage. Does not populate the full cache.
+ */
+export async function loadPublicSyncConfig(): Promise<PublicSyncConfig> {
+  try {
+    const { body } = await cacheFetch<PublicSyncConfig>("/api/config/client-sync/public");
+    return body;
+  } catch {
+    return {
+      tournamentWindowLeadHours: DEFAULTS.tournamentWindowLeadHours,
+      tournamentWindowTailHours: DEFAULTS.tournamentWindowTailHours,
+    };
+  }
+}
+
+/** Synchronous accessor returning the cached value or defaults. Never throws. */
+export function getSyncConfig(): FullSyncConfig {
+  return cached ?? DEFAULTS;
+}
+
+/** Convenience: the RavenEye→RavenBrain poll interval, in milliseconds. */
+export function getRaveneyePollMs(): number {
+  return getSyncConfig().raveneyePollMs;
+}
+
+/** Convenience: tournament-window lead/tail in hours. */
+export function getTournamentWindowBounds(): {
+  leadHours: number;
+  tailHours: number;
+} {
+  const c = getSyncConfig();
+  return { leadHours: c.tournamentWindowLeadHours, tailHours: c.tournamentWindowTailHours };
+}
+
+/** Convenience: report-body TTL in days. */
+export function getReportBodyTtlDays(): number {
+  return getSyncConfig().reportBodyTtlDays;
+}
+
+/** Test-only / "clear caches" support. */
+export function __resetSyncConfigForTests(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/app/common/storage/tournamentWindow.ts
+++ b/app/common/storage/tournamentWindow.ts
@@ -1,0 +1,58 @@
+import type { RBTournament } from "~/types/RBTournament.ts";
+import { serverNow } from "~/common/storage/serverTime.ts";
+
+/**
+ * Tournament-window helpers. The server emits {@code activeFrom} and {@code activeUntil}
+ * timestamps on every tournament (computed from the start/end times plus the configured
+ * lead/tail in {@code raven-eye.sync.tournament-window-*-hours}). The client computes its own
+ * {@code active} boolean on every render by comparing those timestamps against
+ * {@link serverNow}.
+ *
+ * <p>This design is what eliminates the original {@code ACTIVE_TOURNAMENT_CUTOFF} client-side
+ * constant and the ETag/active-field mismatch that would otherwise let a client hold
+ * {@code active: false} long after the tournament actually started.
+ *
+ * <p>Backward compatibility: if a cached tournament record predates Unit 4 (so
+ * {@code activeFrom}/{@code activeUntil} are missing), the helpers fall back to the pre-Unit-4
+ * approximation ("started within the last 36 hours") so pages continue to work while the next
+ * sync refreshes the IndexedDB entries. The fallback is deliberately generous — better to
+ * overcount "active" briefly than to hide a real active tournament.
+ */
+
+const LEGACY_CUTOFF_MS = 36 * 60 * 60 * 1000;
+
+function parseInstantMs(value: string | undefined | Date): number | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.getTime();
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Returns true if {@code t} is currently within its tournament window — i.e., between
+ * {@code activeFrom} and {@code activeUntil} in server time (skew-corrected).
+ */
+export function isTournamentActive(t: RBTournament | undefined | null): boolean {
+  if (!t) return false;
+  const now = serverNow();
+  const from = parseInstantMs(t.activeFrom);
+  const until = parseInstantMs(t.activeUntil);
+  if (from !== null && until !== null) {
+    return now >= from && now <= until;
+  }
+  // Legacy fallback: treat a tournament as active if its startTime is within the last 36h
+  // and we have nothing better. Conservatively overcounts rather than hiding real tournaments.
+  const start = parseInstantMs(t.startTime);
+  if (start === null) return false;
+  return start < now && start > now - LEGACY_CUTOFF_MS;
+}
+
+/** True when any tournament in the list is currently active. */
+export function hasAnyActiveTournament(list: RBTournament[]): boolean {
+  return list.some(isTournamentActive);
+}
+
+/** Return only the active tournaments from a list. */
+export function activeTournaments(list: RBTournament[]): RBTournament[] {
+  return list.filter(isTournamentActive);
+}

--- a/app/common/sync/reportSync.ts
+++ b/app/common/sync/reportSync.ts
@@ -1,0 +1,123 @@
+import { cacheFetch } from "~/common/storage/cacheFetch.ts";
+import { rbfetch } from "~/common/storage/rbauth.ts";
+import {
+  reportBodies,
+  reportMetadataStore,
+  type ReportBodyRecord,
+  type ReportMetadataRecord,
+} from "~/common/storage/reportCache.ts";
+import { serverNow } from "~/common/storage/serverTime.ts";
+import { getReportBodyTtlDays } from "~/common/storage/syncConfig.ts";
+
+/**
+ * Report caching layer (Unit 6). Backs the reports-in-IndexedDB model:
+ *
+ * <ul>
+ *   <li>{@link syncReportMetadata} pulls the season-wide {@code [{cachekey, created}]} list
+ *       from {@code GET /api/report/metadata} and writes it to {@code reportMetadataStore}.
+ *       Runs on the sync-tick loop at the tournament-window cadence when the user has reports
+ *       access. Via {@link cacheFetch} the call is a 304 in steady state.
+ *   <li>{@link pullReportBody} fetches a specific cached report by its cachekey and writes the
+ *       body to {@code reportBodies} along with the current {@code created} version from the
+ *       metadata table. Called by the {@code useReportBody(key)} hook (added by the report page
+ *       migrations) on first open and again when the metadata version bumps.
+ *   <li>{@link prewarmOneReportBody} pulls one body per tick whose local {@code versionStored}
+ *       is behind the server {@code created}. Low-priority; runs only when the rest of the tick
+ *       did no other network work.
+ *   <li>{@link evictExpiredReportBodies} runs inside the sync-tick eviction pass (added in
+ *       Unit 7) and deletes bodies whose {@code pulledAt} is older than
+ *       {@code raven-eye.sync.report-body-ttl-days}.
+ * </ul>
+ *
+ * <p>Endpoint-to-URL rule: a cachekey like {@code "pmva:v5:2026onto"} maps to the already-
+ * existing server endpoint that produces it. Rather than hard-code every mapping here, the
+ * body-pull helpers accept a URL directly; the {@code useReportBody} hook owns the cachekey →
+ * URL translation, which is a per-report-page concern.
+ */
+
+/** Call the metadata endpoint; writes every tuple to IndexedDB. */
+export async function syncReportMetadata(): Promise<void> {
+  const { body } = await cacheFetch<ReportMetadataRecord[]>("/api/report/metadata");
+  await reportMetadataStore.putAll(body);
+}
+
+/** Read all metadata tuples from IndexedDB. */
+export async function listReportMetadata(): Promise<ReportMetadataRecord[]> {
+  return reportMetadataStore.getAll();
+}
+
+/** Read one metadata tuple from IndexedDB. */
+export async function getReportMetadata(
+  cachekey: string,
+): Promise<ReportMetadataRecord | null> {
+  return reportMetadataStore.get(cachekey);
+}
+
+/** Read one body from IndexedDB. */
+export async function getCachedReportBody(
+  cachekey: string,
+): Promise<ReportBodyRecord | null> {
+  return reportBodies.get(cachekey);
+}
+
+/**
+ * Fetch a report body from the server, store it in IndexedDB, return the record. Caller supplies
+ * the {@code url} (the specific report endpoint) and the {@code version} timestamp that the body
+ * corresponds to (typically the {@code created} from the matching metadata tuple). {@link cacheFetch}
+ * is not used here — the existing report endpoints already emit weak ETags via Unit 1, but the
+ * client wants each body in its own IndexedDB record, not in the shared apiEtags cache.
+ */
+export async function pullReportBody(
+  cachekey: string,
+  url: string,
+  version: number,
+): Promise<ReportBodyRecord> {
+  const resp = await rbfetch(url, {});
+  if (!resp.ok) {
+    throw new Error(
+      `Failed to fetch report body for ${cachekey} at ${url}: ${resp.status}`,
+    );
+  }
+  const body = await resp.json();
+  const record: ReportBodyRecord = {
+    cachekey,
+    body,
+    versionStored: version,
+    pulledAt: serverNow(),
+  };
+  await reportBodies.put(record);
+  return record;
+}
+
+/**
+ * Find one metadata tuple whose body is missing or stale and pull it. Returns true when it did
+ * work (caller can gate other low-priority jobs on that). The URL lookup uses the same
+ * cachekey → URL mapping the hooks use, passed in by the registered job so reportSync.ts does
+ * not have to know every endpoint shape.
+ */
+export async function prewarmOneReportBody(
+  cacheKeyToUrl: (cachekey: string) => string | null,
+): Promise<boolean> {
+  const metadata = await listReportMetadata();
+  for (const m of metadata) {
+    const existing = await getCachedReportBody(m.cachekey);
+    const serverVersion = new Date(m.created).getTime();
+    if (existing && existing.versionStored >= serverVersion) continue;
+    const url = cacheKeyToUrl(m.cachekey);
+    if (!url) continue;
+    await pullReportBody(m.cachekey, url, serverVersion);
+    return true;
+  }
+  return false;
+}
+
+/** Evict report bodies older than the configured TTL. Returns the count evicted. */
+export async function evictExpiredReportBodies(): Promise<number> {
+  const ttlMs = getReportBodyTtlDays() * 24 * 60 * 60 * 1000;
+  const cutoff = serverNow() - ttlMs;
+  const all = await reportBodies.getAll();
+  const victims = all.filter((b) => b.pulledAt < cutoff).map((b) => b.cachekey);
+  if (victims.length === 0) return 0;
+  await reportBodies.deleteMany(victims);
+  return victims.length;
+}

--- a/app/common/sync/sync.ts
+++ b/app/common/sync/sync.ts
@@ -27,6 +27,10 @@ import {
   hasAnyActiveTournament,
   activeTournaments,
 } from "~/common/storage/tournamentWindow.ts";
+import {
+  syncReportMetadata,
+  evictExpiredReportBodies,
+} from "~/common/sync/reportSync.ts";
 import { useSyncStatus } from "~/common/storage/dbhooks.ts";
 import { getNetworkHealth } from "~/common/storage/networkHealth.ts";
 
@@ -127,6 +131,21 @@ function hasSession(): boolean {
   );
 }
 
+/** True when the logged-in user holds a role with reports access. */
+function hasReportsRole(): boolean {
+  if (typeof sessionStorage === "undefined") return false;
+  const raw = sessionStorage.getItem("raveneye_roles");
+  if (!raw) return false;
+  try {
+    const roles = JSON.parse(raw) as string[];
+    return roles.some(
+      (r) => r === "ROLE_EXPERTSCOUT" || r === "ROLE_ADMIN" || r === "ROLE_SUPERUSER",
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function windowActive(): Promise<boolean> {
   const tournaments = await repository.getTournamentList();
   return hasAnyActiveTournament(tournaments);
@@ -159,6 +178,24 @@ const JOBS: SyncJob[] = [
     cadenceMs: 30_000,
     precondition: async () => hasSession() && (await windowActive()) && getNetworkHealth().alive === true,
     run: () => syncRobotAlertList(),
+    lastRunAt: 0,
+  },
+  {
+    id: "report-metadata",
+    cadenceMs: 30_000,
+    precondition: async () =>
+      hasSession() && hasReportsRole() && (await windowActive()) && getNetworkHealth().alive === true,
+    run: () => syncReportMetadata(),
+    lastRunAt: 0,
+  },
+  {
+    id: "report-body-eviction",
+    // Evict expired report bodies once per hour — TTL-driven; no tournament-window gate.
+    cadenceMs: 60 * 60 * 1000,
+    precondition: () => hasSession(),
+    run: async () => {
+      await evictExpiredReportBodies();
+    },
     lastRunAt: 0,
   },
 ];

--- a/app/common/sync/sync.ts
+++ b/app/common/sync/sync.ts
@@ -95,11 +95,100 @@ async function runSync(
   }
 }
 
-const SCHEDULE_SYNC_INTERVAL = 3 * 60 * 1000; // 3 minutes
-const TRACKING_DATA_SYNC_INTERVAL = 15 * 1000; // 15 seconds
+// Upload queue cadence (own setInterval — offline-first priority, never blocked by
+// reference-data fetches). Unit 5's design: uploads first, reads second.
+const UPLOAD_TICK_MS = 15 * 1000;
+// JOBS-scheduler tick cadence. 5 seconds balances responsiveness (a job overdue by >5s
+// starts within 5s) against battery / wakeup cost (all individual jobs have cadence ≥30s).
+const SYNC_TICK_MS = 5 * 1000;
 // Unit 4 removed the ACTIVE_TOURNAMENT_CUTOFF constant: tournament activity is now
 // computed from server-emitted activeFrom/activeUntil timestamps in
 // ~/common/storage/tournamentWindow.ts (which corrects for device clock skew).
+
+/**
+ * A single background sync job. The scheduler loop walks an inline array of these and runs each
+ * when its {@code precondition} returns true and {@code cadenceMs} has elapsed since its last
+ * run. Array order is load-bearing: jobs earlier in the array see each tick first, so data
+ * dependencies (e.g., tournament list must land before strategy plans can filter by
+ * active-tournament) are preserved by position.
+ */
+interface SyncJob {
+  id: string;
+  cadenceMs: number;
+  precondition: () => Promise<boolean> | boolean;
+  run: () => Promise<void>;
+  lastRunAt: number;
+}
+
+function hasSession(): boolean {
+  return (
+    typeof sessionStorage !== "undefined" &&
+    sessionStorage.getItem("raveneye_access_token") !== null
+  );
+}
+
+async function windowActive(): Promise<boolean> {
+  const tournaments = await repository.getTournamentList();
+  return hasAnyActiveTournament(tournaments);
+}
+
+/**
+ * Inline registry of every background sync job. Adding a new job is appending one entry here;
+ * the scheduler body never changes.
+ *
+ * <p>Cadences default to 30s inside the tournament window and idle outside it (preconditions
+ * gate that). The 5s tick means a job is picked up within 5s of becoming overdue.
+ */
+const JOBS: SyncJob[] = [
+  {
+    id: "match-schedule",
+    cadenceMs: 30_000,
+    precondition: async () => hasSession() && (await windowActive()) && getNetworkHealth().alive === true,
+    run: () => syncMatchSchedule(),
+    lastRunAt: 0,
+  },
+  {
+    id: "strategy-plans",
+    cadenceMs: 30_000,
+    precondition: async () => hasSession() && (await windowActive()) && getNetworkHealth().alive === true,
+    run: () => syncStrategyPlans(),
+    lastRunAt: 0,
+  },
+  {
+    id: "robot-alert-list",
+    cadenceMs: 30_000,
+    precondition: async () => hasSession() && (await windowActive()) && getNetworkHealth().alive === true,
+    run: () => syncRobotAlertList(),
+    lastRunAt: 0,
+  },
+];
+
+/** Append a job at runtime. Used by feature modules (e.g. Unit 5's nt-keys/kiosk pages). */
+export function registerSyncJob(job: Omit<SyncJob, "lastRunAt">): void {
+  if (JOBS.some((j) => j.id === job.id)) return;
+  JOBS.push({ ...job, lastRunAt: 0 });
+}
+
+async function syncTick(): Promise<void> {
+  const now = Date.now();
+  for (const job of JOBS) {
+    if (now - job.lastRunAt < job.cadenceMs) continue;
+    let ok = false;
+    try {
+      ok = (await Promise.resolve(job.precondition())) === true;
+    } catch {
+      ok = false;
+    }
+    if (!ok) continue;
+    try {
+      await job.run();
+    } catch (err) {
+      console.warn("syncTick job failed:", job.id, err);
+    } finally {
+      job.lastRunAt = Date.now();
+    }
+  }
+}
 
 let syncInitialized = false;
 
@@ -113,16 +202,15 @@ export function initializeSyncSchedule() {
   updateStrategyPlansUnsyncCount();
 
   // Sync server data on startup if the user has a session
-  const hasSession =
-    typeof sessionStorage !== "undefined" &&
-    sessionStorage.getItem("raveneye_access_token") !== null;
-  if (hasSession) {
+  if (hasSession()) {
     doServerDataSync();
   }
 
-  setInterval(autoSyncMatchSchedule, SCHEDULE_SYNC_INTERVAL);
-  setInterval(autoSyncStrategyPlans, SCHEDULE_SYNC_INTERVAL);
-  setInterval(autoSyncTrackingData, TRACKING_DATA_SYNC_INTERVAL);
+  // Two-loop scheduler (Unit 5). Uploads run on their own 15s tick — offline-first
+  // priority, never blocked by a slow reference-data fetch. Everything else walks the
+  // JOBS array on the 5s tick at its own configured cadence.
+  setInterval(autoSyncTrackingData, UPLOAD_TICK_MS);
+  setInterval(syncTick, SYNC_TICK_MS);
 }
 
 /**
@@ -155,37 +243,9 @@ async function autoSyncTrackingData(): Promise<void> {
   await syncTrackingData();
 }
 
-async function autoSyncStrategyPlans(): Promise<void> {
-  const hasSession =
-    typeof sessionStorage !== "undefined" &&
-    sessionStorage.getItem("raveneye_access_token") !== null;
-  if (!hasSession) return;
-  const active = await hasActiveTournament();
-  if (!active) return;
-  const { alive } = getNetworkHealth();
-  if (alive !== true) return;
-  await syncStrategyPlans();
-}
-
-async function hasActiveTournament(): Promise<boolean> {
-  const tournaments = await repository.getTournamentList();
-  return hasAnyActiveTournament(tournaments);
-}
-
-async function autoSyncMatchSchedule(): Promise<void> {
-  const hasSession =
-    typeof sessionStorage !== "undefined" &&
-    sessionStorage.getItem("raveneye_access_token") !== null;
-  if (!hasSession) return;
-
-  const active = await hasActiveTournament();
-  if (!active) return;
-
-  const { alive } = getNetworkHealth();
-  if (alive !== true) return;
-
-  await syncMatchSchedule();
-}
+// Unit 5 inlined the auto-sync guards into JOBS[].precondition. The old
+// autoSyncMatchSchedule / autoSyncStrategyPlans wrappers are gone — every sync trigger now
+// goes through either initializeSyncSchedule()'s JOBS loop or doManualSync().
 
 export async function doManualSync() {
   const { alive } = getNetworkHealth();

--- a/app/common/sync/sync.ts
+++ b/app/common/sync/sync.ts
@@ -23,6 +23,10 @@ import {
   parseDrawingStrokes,
 } from "~/common/storage/rb.ts";
 import type { RBPlanWithDrawings } from "~/common/storage/rb.ts";
+import {
+  hasAnyActiveTournament,
+  activeTournaments,
+} from "~/common/storage/tournamentWindow.ts";
 import { useSyncStatus } from "~/common/storage/dbhooks.ts";
 import { getNetworkHealth } from "~/common/storage/networkHealth.ts";
 
@@ -93,7 +97,9 @@ async function runSync(
 
 const SCHEDULE_SYNC_INTERVAL = 3 * 60 * 1000; // 3 minutes
 const TRACKING_DATA_SYNC_INTERVAL = 15 * 1000; // 15 seconds
-const ACTIVE_TOURNAMENT_CUTOFF = 36 * 60 * 60 * 1000; // 36 hours
+// Unit 4 removed the ACTIVE_TOURNAMENT_CUTOFF constant: tournament activity is now
+// computed from server-emitted activeFrom/activeUntil timestamps in
+// ~/common/storage/tournamentWindow.ts (which corrects for device clock skew).
 
 let syncInitialized = false;
 
@@ -163,8 +169,7 @@ async function autoSyncStrategyPlans(): Promise<void> {
 
 async function hasActiveTournament(): Promise<boolean> {
   const tournaments = await repository.getTournamentList();
-  const cutoff = Date.now() - ACTIVE_TOURNAMENT_CUTOFF;
-  return tournaments.some((t) => new Date(t.endTime).getTime() > cutoff);
+  return hasAnyActiveTournament(tournaments);
 }
 
 async function autoSyncMatchSchedule(): Promise<void> {
@@ -254,11 +259,7 @@ export async function syncSequenceTypeList() {
 export async function syncMatchSchedule() {
   await runSync(MATCH_SCHEDULE, async () => {
     const tournaments = await repository.getTournamentList();
-
-    const cutoff = Date.now() - ACTIVE_TOURNAMENT_CUTOFF;
-    const activeTournamentIds = tournaments
-      .filter((t) => new Date(t.endTime).getTime() > cutoff)
-      .map((t) => t.id);
+    const activeTournamentIds = activeTournaments(tournaments).map((t) => t.id);
     const schedules = await getSchedulesForTournaments(activeTournamentIds);
     await repository.mergeMatchSchedule(schedules);
   });
@@ -571,10 +572,7 @@ async function uploadDirtyStrategyPlans(): Promise<void> {
 
 async function downloadStrategyPlansForActiveTournaments(): Promise<void> {
     const tournaments = await repository.getTournamentList();
-    const cutoff = Date.now() - ACTIVE_TOURNAMENT_CUTOFF;
-    const activeTournamentIds = tournaments
-      .filter((t) => new Date(t.endTime).getTime() > cutoff)
-      .map((t) => t.id);
+    const activeTournamentIds = activeTournaments(tournaments).map((t) => t.id);
     for (const tid of activeTournamentIds) {
       const remote = await getStrategyPlansForTournament(tid);
       for (const pwd of remote) {
@@ -735,10 +733,7 @@ export const useStrategyPlansSyncStatus = (): SyncStatus => {
 export async function syncRobotAlertList() {
   await runSync(ROBOT_ALERT_LIST, async () => {
     const tournaments = await repository.getTournamentList();
-    const cutoff = Date.now() - ACTIVE_TOURNAMENT_CUTOFF;
-    const activeTournamentIds = tournaments
-      .filter((t) => new Date(t.endTime).getTime() > cutoff)
-      .map((t) => t.id);
+    const activeTournamentIds = activeTournaments(tournaments).map((t) => t.id);
     const data = await getRobotAlertListBulk(activeTournamentIds);
     await repository.putRobotAlerts(data);
   });

--- a/app/routes/admin/tournament-streams-page.tsx
+++ b/app/routes/admin/tournament-streams-page.tsx
@@ -6,6 +6,7 @@ import {
   removeTournamentWebcast,
   setTournamentTbaEventKey,
 } from "~/common/storage/rb.ts";
+import { minutesAgo } from "~/common/storage/serverTime.ts";
 import type { RBTournament } from "~/types/RBTournament.ts";
 import Spinner from "~/common/Spinner.tsx";
 import TournamentPicker from "~/common/components/TournamentPicker.tsx";
@@ -43,7 +44,8 @@ function parseWebcasts(tournament: RBTournament): string[] {
 function relativeAgo(iso: string): string {
   const then = Date.parse(iso);
   if (isNaN(then)) return iso;
-  const minutes = Math.round((Date.now() - then) / 60000);
+  // minutesAgo() corrects for any device clock skew using the server-time header.
+  const minutes = minutesAgo(then);
   if (minutes < 1) return "just now";
   if (minutes < 60) return `${minutes} min ago`;
   const hours = Math.round(minutes / 60);

--- a/app/types/RBTournament.ts
+++ b/app/types/RBTournament.ts
@@ -20,4 +20,10 @@ export type RBTournament = {
   webcastsStale?: boolean;
   // TBA event key (e.g. "2026onto") — admin-editable (see Unit 7) when auto-derivation was wrong.
   tbaEventKey?: string | null;
+  // Tournament-window bounds, server-computed from startTime/endTime + the configured lead/tail.
+  // Client uses serverNow() to compute "is this tournament currently active?" locally each render
+  // — see common/storage/tournamentWindow.ts. Optional for backward compatibility with cached
+  // entries written before Unit 4 added these fields.
+  activeFrom?: string;
+  activeUntil?: string;
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,135 @@
+# RavenEye Architecture
+
+Companion to `RavenBrain/doc/architecture.md`. This document describes the client-side
+half of the system — how RavenEye stores, reads, and synchronizes data. For REST-endpoint,
+caching, and server-timer details see the RavenBrain architecture doc.
+
+## System Context
+
+RavenEye is a React SPA (React 19, React Router 7 in framework mode, client-side only) built
+with Vite 7. It talks to exactly one backend — RavenBrain. Track pages are designed to work
+offline after an initial sync; report and admin pages generally assume connectivity.
+
+## Design Posture (Unit 9, network-communication-refinement)
+
+The refinement captured in
+[`docs/brainstorms/2026-04-18-network-communication-refinement-requirements.md`](brainstorms/2026-04-18-network-communication-refinement-requirements.md)
+and
+[`docs/plans/2026-04-19-001-feat-network-communication-refinement-plan.md`](plans/2026-04-19-001-feat-network-communication-refinement-plan.md)
+established these standing rules. Every change to the client-server boundary should
+maintain them.
+
+### Server-push is rejected
+
+No WebSockets, no SSE, no server-push mechanism of any kind. Rationale: servlet-mode
+architectural simplicity and student-contributor readability. (The "degrades gracefully on
+flaky WiFi" argument is contested and is deliberately not used as justification — polling
+with staggered jitter degrades at least as well, and reconnect storms on a push design are
+not an improvement at a tournament.)
+
+### Offline-first reads go through IndexedDB, except admin screens
+
+Every non-admin page reads its data from IndexedDB. Background sync keeps IndexedDB fresh
+from the server. If a page component issues a direct `fetch` / `rbfetch` to populate what
+it renders, it's either an admin page (user management, event/sequence/strategy-area admin,
+tournament config, field calibration, FRC/config-sync triggers, match videos, Nexus debug)
+or it's a bug against this posture.
+
+Two narrow exceptions that stay on raw `fetch()` because the endpoints are anonymous:
+`getActiveTeamTournaments()` and the public team-schedule pass-through. The kiosk-pit and
+home-page displays that use them accept network-required behavior for that specific call.
+
+### Conditional GETs with weak ETags
+
+`app/common/storage/cacheFetch.ts` wraps `rbfetch` and issues conditional requests. The
+server emits a weak `ETag`; `cacheFetch` sends `If-None-Match` on the next call and returns
+a parsed body without re-parsing on 304. ETags are persisted per-URL in the `apiEtags`
+IndexedDB store along with the parsed body so 304 responses can serve from cache without
+forcing every caller to maintain its own fallback.
+
+The 401-refresh-retry inside `rbfetch` is unchanged; `cacheFetch` only sees the
+post-refresh response. Write endpoints and anonymous endpoints bypass the cache layer.
+
+### Clock-skew tolerance is centralized
+
+`app/common/storage/serverTime.ts` maintains a bounded client-server clock offset using the
+`X-RavenBrain-Time` header emitted on every response. `serverNow()` is used instead of
+`Date.now()` anywhere a client-side timestamp is compared against a server-emitted one —
+JWT expiration checks in `rbauth.ts`, "N minutes ago" renders in
+`tournament-streams-page.tsx`, tournament-window membership via `tournamentWindow.ts`.
+`Date.now()` continues to drive local UI timers (countdowns, drill timeouts, draw-tool
+persistence) where clock skew is irrelevant.
+
+Clamp and max-age rules are in the module's top comment. The short version: bounded single
+updates (±5 min) and a last-good TTL (12 h) matching the JWT access-token lifetime.
+
+### Server owns the tournament window
+
+`TournamentResponse.activeFrom` and `activeUntil` are computed server-side from start/end
+plus the configured lead/tail. The client derives `active` locally via `serverNow()` rather
+than storing a server-emitted boolean. This avoids an ETag mismatch where a tournament's
+`active` status flips mid-window but no row has been modified, so the ETag would be stale
+and the client would keep showing the old value.
+
+### Two-loop sync scheduler
+
+`app/common/sync/sync.ts` drives exactly two `setInterval` loops:
+
+- **Upload loop, 15s.** Drains the outbound tracking queues (events, quick comments, robot
+  alerts, strategy plans). Offline-first priority — never blocked by a slow reference-data
+  fetch.
+- **Sync loop, 5s tick.** Walks an inline `JOBS` array. Each descriptor declares cadence,
+  precondition, run. Adding a new sync is one entry in the array. Cadences default to 30s
+  inside the tournament window and idle outside it via preconditions.
+
+### Online indicator is derived, not polled
+
+`app/common/storage/networkHealth.ts` tracks a `lastOk` timestamp updated on every
+qualifying response (HTTP 200, `Content-Type: application/json`, `/api/*` path,
+`X-RavenBrain-Version` header present, non-empty JSON body; and for `/api/ping` specifically
+a body shape of `{pong: true, version: string}`). In steady state, no dedicated pings fire
+— the indicator rides real traffic. A fallback ping runs only when `lastOk` ages beyond 15s.
+Captive portals returning 200 text/html or generic JSON blobs fail the qualifier and leave
+the indicator offline, correctly.
+
+### Cache lifecycle on identity boundaries
+
+Read-only caches (ETags, reference data, report metadata/bodies, strategy plans) are wiped
+on explicit logout and on a same-device login that produces a different username. Outbound
+tracking queues are preserved across both events so a scout who accidentally logs out on a
+bad-WiFi day does not lose captured events. The dedicated "Clear caches and log out
+(discard pending events)" UI is future polish; the `clearDataCaches()` helper that backs it
+already exists in `app/common/storage/cacheClear.ts`.
+
+### Role-change detection via fingerprint
+
+`X-RavenBrain-Role-FP` (first 12 hex chars of SHA-256 over the user's sorted role list) is
+emitted by RavenBrain on 200 authenticated responses and is *not* CORS-exposed — browser
+JS in the RavenEye origin cannot read it, so an XSS payload in this origin cannot harvest
+role data. `doRbFetch` tracks the fingerprint in sessionStorage and fires an async
+`/api/validate` when it changes mid-session so `useRole()` subscribers can recompute.
+
+## Data-Source Authority (mirrored from RavenBrain/doc/architecture.md)
+
+- **FRC API is authoritative** for match scores and schedules.
+- **TBA is the source** for derived event data (webcasts today, more over time). See
+  [`docs/tba-data-foundation.md`](tba-data-foundation.md).
+- **Statbotics** is designated for quantitative analytics and statistics. Not yet
+  integrated; the architecture does not preclude adding it.
+
+## File Layout Quick Reference
+
+| Concern | File |
+|---|---|
+| JWT auth, rbfetch, 401 retry | `app/common/storage/rbauth.ts` |
+| API wrappers (typed per-endpoint functions + hooks) | `app/common/storage/rb.ts` |
+| IndexedDB repository | `app/common/storage/db.ts` |
+| Conditional GET abstraction | `app/common/storage/cacheFetch.ts` |
+| Sync cadence config (server-delivered) | `app/common/storage/syncConfig.ts` |
+| Clock-skew tolerance | `app/common/storage/serverTime.ts` |
+| Tournament-window helpers | `app/common/storage/tournamentWindow.ts` |
+| Online-indicator state | `app/common/storage/networkHealth.ts` |
+| Cache-clear on logout / username change | `app/common/storage/cacheClear.ts` |
+| Report metadata + body cache | `app/common/storage/reportCache.ts` |
+| Sync scheduler and JOBS array | `app/common/sync/sync.ts` |
+| Report sync (metadata, pre-warm, TTL eviction) | `app/common/sync/reportSync.ts` |

--- a/docs/tba-data-foundation.md
+++ b/docs/tba-data-foundation.md
@@ -9,6 +9,34 @@ origin: RavenEye/docs/brainstorms/2026-04-17-team-capability-rankings-requiremen
 
 # TBA Data Foundation and Webcast Sync (P0)
 
+> **2026-04-19 — Alignment note from network-communication-refinement (Unit 9).**
+> The network-communication-refinement work
+> (`RavenEye/docs/plans/2026-04-19-001-feat-network-communication-refinement-plan.md`)
+> has landed and this plan is halted awaiting a resume. When it resumes, the following
+> adjustments are already in place and should be reflected in the implementation rather
+> than re-introduced:
+>
+> - `TbaEventSyncService` and `TbaMatchSyncService` no longer use hardcoded
+>   `@Scheduled(fixedDelay = "1h")` literals. Both read from `raven-eye.sync.tba-event-poll`
+>   and `raven-eye.sync.tba-match-poll` in the unified sync-config block.
+> - `TournamentResponse` now carries `activeFrom` / `activeUntil` in addition to the
+>   webcast fields this plan adds. No conflict — they're independent additive fields.
+> - `TournamentEnricher` has a four-arg constructor (adds `windowLeadHours` and
+>   `windowTailHours`). Tests construct it via reflection; the P0 plan's test scaffolding
+>   should follow the same pattern.
+> - `GET /api/tournament` emits a weak ETag and supports `If-None-Match`; the webcast
+>   fields this plan adds are included inside that ETag naturally because the controller
+>   is `@Transactional(readOnly = true)` and the version source is `MAX(updated_at)` over
+>   `RB_TOURNAMENT` — writes by either FRC or TBA bump `updated_at` and the ETag changes.
+> - `tournament-streams-page.tsx` relative-time display goes through
+>   `minutesAgo()` from the skew-tolerance module instead of raw `Date.now()`. No
+>   action needed by this plan; the staleness banner rendering already uses the helper.
+> - "Server computes staleness booleans, client displays them" is the canonical
+>   pattern — `webcastsStale` (this plan) is the exemplar. Continue this posture for any
+>   new staleness indicator added in subsequent phases.
+> - Flyway migrations: V34 landed with this refinement. Any new migration in subsequent
+>   P-level phases should be V35 or later.
+
 **Target repos:** `RavenBrain` (primary — new `tbaapi` package, migrations, sync service) and `RavenEye` (minimal UI change — admin-page source indicator + staleness banner). All file paths in this plan are monorepo-relative, prefixed with `RavenBrain/` or `RavenEye/`.
 
 ## Overview


### PR DESCRIPTION
- **feat: add centralized clock-skew tolerance module (Unit 2)**
- **feat: add cacheFetch + syncConfig + migrate high-value GETs (Unit 3, client)**
- **feat: tournament-window helper + sync.ts ACTIVE_TOURNAMENT_CUTOFF removal (Unit 4)**
- **feat: two-loop sync scheduler + JOBS registry (Unit 5)**
- **feat: reports-in-IndexedDB infrastructure + metadata sync job (Unit 6, client)**
- **feat: role-fingerprint detection + cache lifecycle on login/logout (Unit 7, client)**
- **feat: online indicator from lastOk + tight liveness qualifier (Unit 8, client)**
- **docs: add client architecture doc + TBA-plan alignment note (Unit 9)**
