### PR TITLE
feat/team capability rankings p1

### DIFF
--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -3587,3 +3587,115 @@ a.kiosk-brand {
     border-color: var(--alliance-red);
 }
 
+/* ──────────────────────────────────────────────────────────────────────── */
+/* Team Capability — Unit 7                                                 */
+/* Tournament Teams card on team-schedule page.                             */
+/* ──────────────────────────────────────────────────────────────────────── */
+
+.tournament-teams-card .tournament-teams-table {
+    font-size: 0.75rem;
+}
+
+.tournament-teams-card .tournament-teams-table tbody tr {
+    cursor: pointer;
+}
+
+.tournament-teams-card .tournament-teams-table tbody tr:hover {
+    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.04));
+}
+
+@media (prefers-color-scheme: dark) {
+    .tournament-teams-card .tournament-teams-table tbody tr:hover {
+        background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.06));
+    }
+}
+
+.tournament-teams-card .tt-col-team {
+    text-align: left;
+    white-space: nowrap;
+}
+
+.tournament-teams-card .tt-team-number {
+    font-weight: 700;
+}
+
+.tournament-teams-card .tt-team-name {
+    color: var(--color-text-secondary);
+    font-weight: normal;
+}
+
+.tournament-teams-card .tt-loading-cell,
+.tournament-teams-card .tt-empty-cell {
+    text-align: center;
+    font-style: italic;
+    color: var(--color-text-secondary);
+    padding: 0.75rem;
+}
+
+/* Withdrawn rows: line-through for the whole row. Values remain visible
+ * for historical reference; sort position is always last (enforced in JS). */
+.tournament-teams-row-withdrawn {
+    text-decoration: line-through;
+    color: var(--color-text-tertiary);
+}
+
+/* Hide "wide" columns in portrait-iPhone so only Team | Overall EPA | OPR
+ * remain. Matches the existing .schedule-rotate-hint breakpoint. */
+@media (max-width: 480px) and (orientation: portrait) {
+    .tournament-teams-card .tt-col-wide {
+        display: none;
+    }
+}
+
+/*
+ * Scouting-coverage pill. Text label ("Full" / "Thin" / "None") is the primary
+ * channel; Paul Tol vibrant colour + border shape are redundant channels so
+ * CB users can still distinguish states.
+ */
+.badge-scouting-full,
+.badge-scouting-thin,
+.badge-scouting-none {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: bold;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.75rem;
+    vertical-align: middle;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+}
+
+.badge-scouting-full {
+    background-color: #009988; /* Tol vibrant teal */
+    color: #fff;
+    border: 1px solid #009988;
+}
+
+.badge-scouting-thin {
+    background-color: #EE7733; /* Tol vibrant orange */
+    color: #000;
+    border: 1px solid #EE7733;
+}
+
+.badge-scouting-none {
+    background-color: transparent;
+    color: var(--color-text-secondary);
+    border: 1px dashed #BBBBBB; /* Tol vibrant grey, dashed for shape redundancy */
+}
+
+@media (prefers-color-scheme: dark) {
+    .badge-scouting-full {
+        background-color: #00BBAA;
+        color: #000;
+        border-color: #00BBAA;
+    }
+    .badge-scouting-thin {
+        background-color: #FF9955;
+        color: #000;
+        border-color: #FF9955;
+    }
+    .badge-scouting-none {
+        border-color: #888888;
+    }
+}
+

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -3610,6 +3610,19 @@ a.kiosk-brand {
     }
 }
 
+.tournament-teams-card .tt-col-rank {
+    text-align: right;
+    width: 1%;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-secondary);
+}
+
+.tournament-teams-card tbody .tt-col-rank {
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
 .tournament-teams-card .tt-col-team {
     text-align: left;
     white-space: nowrap;

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -3699,3 +3699,116 @@ a.kiosk-brand {
     }
 }
 
+/* ──────────────────────────────────────────────────────────────────────── */
+/* Team Capability — Unit 8                                                 */
+/* Match Teams table on match strategy page.                                */
+/*                                                                          */
+/* Alliance colour on the row background + a textual "Red" / "Blue" label   */
+/* column are redundant channels so colour-blind users and screen readers   */
+/* can always identify alliance membership.                                 */
+/* ──────────────────────────────────────────────────────────────────────── */
+
+.match-teams-card .match-teams-table {
+    font-size: 0.75rem;
+}
+
+.match-teams-card .match-teams-table tbody tr {
+    cursor: pointer;
+}
+
+/* Alliance-colour row tinting (light mode). The --alliance-red-bg /
+ * --alliance-blue-bg variables are dark-theme values, so light mode needs a
+ * lighter tint. Using rgba of the alliance colour keeps the tint CB-safe
+ * without introducing new variables. */
+.match-teams-card .match-teams-row-red {
+    background-color: rgba(255, 90, 71, 0.08);
+}
+
+.match-teams-card .match-teams-row-blue {
+    background-color: rgba(68, 136, 255, 0.08);
+}
+
+/* Emphasise the alliance boundary between red block and blue block. */
+.match-teams-card .match-teams-alliance-first {
+    border-top: 2px solid var(--color-border, #bbb);
+}
+
+/* Alliance label column — bold, matches alliance text colour.  The label
+ * itself (not colour alone) is the primary CB-safe channel. */
+.match-teams-card .mt-col-alliance {
+    font-weight: 700;
+    white-space: nowrap;
+    text-align: left;
+}
+
+.match-teams-card .match-teams-row-red .mt-col-alliance {
+    color: var(--alliance-red);
+}
+
+.match-teams-card .match-teams-row-blue .mt-col-alliance {
+    color: var(--alliance-blue);
+}
+
+.match-teams-card .mt-col-team {
+    text-align: left;
+    white-space: nowrap;
+}
+
+.match-teams-card .mt-team-number {
+    font-weight: 700;
+}
+
+.match-teams-card .mt-team-name {
+    color: var(--color-text-secondary);
+    font-weight: normal;
+}
+
+.match-teams-card .mt-loading-cell {
+    text-align: center;
+    font-style: italic;
+    color: var(--color-text-secondary);
+    padding: 0.75rem;
+}
+
+/* Withdrawn rows: strike-through the whole row; values remain visible so the
+ * scout can still see historical capability numbers. Rank computation
+ * (JS-side) excludes these rows. */
+.match-teams-card .match-teams-row-withdrawn {
+    text-decoration: line-through;
+    color: var(--color-text-tertiary);
+}
+
+/* Hover affordance — matches Unit 7 convention. Alliance tint wins on the
+ * base row, hover nudges it slightly darker. */
+.match-teams-card .match-teams-table tbody tr:hover {
+    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.06));
+}
+
+.match-teams-card .match-teams-row-red:hover {
+    background-color: rgba(255, 90, 71, 0.18);
+}
+
+.match-teams-card .match-teams-row-blue:hover {
+    background-color: rgba(68, 136, 255, 0.18);
+}
+
+@media (prefers-color-scheme: dark) {
+    /* Dark-mode tints — use the full alliance-*-bg variables which are
+     * already calibrated to be CB-safe against the dark canvas. */
+    .match-teams-card .match-teams-row-red {
+        background-color: var(--alliance-red-bg);
+    }
+    .match-teams-card .match-teams-row-blue {
+        background-color: var(--alliance-blue-bg);
+    }
+    .match-teams-card .match-teams-row-red:hover {
+        background-color: rgba(255, 90, 71, 0.35);
+    }
+    .match-teams-card .match-teams-row-blue:hover {
+        background-color: rgba(68, 136, 255, 0.35);
+    }
+    .match-teams-card .match-teams-table tbody tr:hover {
+        background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.08));
+    }
+}
+

--- a/app/common/storage/cacheClear.ts
+++ b/app/common/storage/cacheClear.ts
@@ -44,6 +44,10 @@ const READ_ONLY_CACHE_STORES: string[] = [
   "customStatsCache",
   "strategyPlans",
   "strategyDrawings",
+  // P1 Unit 6 — team-capability rows. ETag entries in apiEtags are already wiped above, so
+  // adding the object store here is all that's needed to clear capability data on identity
+  // boundaries (logout / username change on a shared device).
+  "teamCapability",
 ];
 
 let dbHandle: IDBDatabase | null = null;

--- a/app/common/storage/db.ts
+++ b/app/common/storage/db.ts
@@ -10,9 +10,11 @@ import type { RBEventLogRecord } from "~/types/RBEventLogRecord.ts";
 import type { RBRobotAlert } from "~/types/RBRobotAlert.ts";
 import type { CustomTournamentStats } from "~/types/TeamSummaryReport.ts";
 import type { StrategyStroke } from "~/types/StrategyStroke.ts";
+import type { TeamCapability } from "~/types/TeamCapability.ts";
 
 const DB_NAME = "RavenEyeDB";
-const DB_VERSION = 15;
+// Bumped to 16 for the team-capability object store (P1 Unit 6).
+const DB_VERSION = 16;
 const SYNC_STATUS_STORE = "syncStatus";
 const TOURNAMENT_LIST_STORE = "tournamentList";
 const STRATEGY_AREAS_STORE = "strategyAreas";
@@ -30,6 +32,10 @@ const TEAM_TOURNAMENT_IDS_STORE = "teamTournamentIds";
 const CUSTOM_STATS_CACHE_STORE = "customStatsCache";
 const STRATEGY_PLAN_STORE = "strategyPlans";
 const STRATEGY_DRAWING_STORE = "strategyDrawings";
+// Team capability rows, keyed by tournamentId. One record per tournament holds the full array
+// of TeamCapability rows emitted by GET /api/team-capability/{tournamentId}. Overwrite-on-write
+// by the sync job; readers (Units 7 & 8) pull straight from IndexedDB to stay offline-capable.
+const TEAM_CAPABILITY_STORE = "teamCapability";
 // HTTP cache metadata: one record per URL holding the most recent ETag returned by RavenBrain.
 // Keyed by URL path so cacheFetch can build conditional GETs (If-None-Match) and short-circuit
 // IndexedDB writes on 304. List-style endpoints (tournament list, strategy areas, ...) get one
@@ -183,6 +189,11 @@ export class Repository {
         }
         if (!db.objectStoreNames.contains("reportBodies")) {
           db.createObjectStore("reportBodies", { keyPath: "cachekey" });
+        }
+        // P1 Unit 6: team-capability rows, one array per tournamentId. Populated by the
+        // JOBS scheduler; read by Units 7 (schedule page) and 8 (strategy page).
+        if (!db.objectStoreNames.contains(TEAM_CAPABILITY_STORE)) {
+          db.createObjectStore(TEAM_CAPABILITY_STORE, { keyPath: "tournamentId" });
         }
       };
     });
@@ -826,6 +837,45 @@ export class Repository {
       store.put(replacement);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  // -------- Team Capability (P1 Unit 6) --------
+
+  /**
+   * Overwrite the team-capability rows for a single tournament. One record in the store holds
+   * the full array under the tournamentId key; the sync job re-writes the whole array on every
+   * refresh (readers Units 7 & 8 always see a consistent snapshot).
+   */
+  async putTeamCapability(
+    tournamentId: string,
+    rows: TeamCapability[],
+  ): Promise<void> {
+    const db = await this.getDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([TEAM_CAPABILITY_STORE], "readwrite");
+      tx.objectStore(TEAM_CAPABILITY_STORE).put({ tournamentId, rows });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  /**
+   * Read the cached team-capability rows for a tournament. Returns an empty array when the
+   * sync has not populated this tournament yet (cold IndexedDB / first-visit offline).
+   */
+  async getTeamCapability(tournamentId: string): Promise<TeamCapability[]> {
+    const db = await this.getDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([TEAM_CAPABILITY_STORE], "readonly");
+      const req = tx.objectStore(TEAM_CAPABILITY_STORE).get(tournamentId);
+      req.onsuccess = () => {
+        const record = req.result as
+          | { tournamentId: string; rows: TeamCapability[] }
+          | undefined;
+        resolve(record?.rows ?? []);
+      };
+      req.onerror = () => reject(req.error);
     });
   }
 

--- a/app/common/storage/db.ts
+++ b/app/common/storage/db.ts
@@ -117,9 +117,28 @@ export class Repository {
       const request = indexedDB.open(DB_NAME, DB_VERSION);
 
       request.onerror = () => reject(request.error);
+      // Another tab/connection is holding the DB at an older version and won't let the
+      // upgrade proceed. Surface a clear error instead of hanging forever; the user must
+      // close the stale tab (or restart the browser) for the upgrade to complete.
+      request.onblocked = () => {
+        reject(
+          new Error(
+            "RavenEye database upgrade is blocked by another tab. " +
+              "Close every other RavenEye tab and reload this page.",
+          ),
+        );
+      };
       request.onsuccess = () => {
-        this.db = request.result;
-        resolve(request.result);
+        const db = request.result;
+        // If another tab tries to upgrade the DB after we've connected, close our
+        // connection voluntarily so the other tab's upgrade can proceed. The repository
+        // reopens lazily on the next call via getDB().
+        db.onversionchange = () => {
+          db.close();
+          this.db = null;
+        };
+        this.db = db;
+        resolve(db);
       };
 
       request.onupgradeneeded = () => {

--- a/app/common/storage/rb.ts
+++ b/app/common/storage/rb.ts
@@ -35,6 +35,7 @@ import type { MatchStrategyPlan } from "~/types/MatchStrategyPlan.ts";
 import type { MatchStrategyDrawing } from "~/types/MatchStrategyDrawing.ts";
 import type { StrategyStroke } from "~/types/StrategyStroke.ts";
 import type { FieldCalibration } from "~/types/FieldCalibration.ts";
+import type { TeamCapability } from "~/types/TeamCapability.ts";
 
 const PING_TIMEOUT_MS = 3000;
 
@@ -1587,5 +1588,27 @@ export async function saveFieldCalibration(
  */
 export async function getTelemetryNtKeys(): Promise<string[]> {
   const { body } = await cacheFetch<string[]>("/api/telemetry/nt-keys");
+  return body;
+}
+
+/**
+ * Fetches the team-capability snapshot for a tournament. One row per registered team merging
+ * TBA OPR, Statbotics EPA, and RavenBrain scouting aggregates with server-computed staleness
+ * flags, coverage classification, and withdrawn detection.
+ *
+ * <p>Uses {@link cacheFetch} so the conditional GET (If-None-Match) short-circuits to the cached
+ * parsed body on 304 — this endpoint is hit on every JOBS-scheduler tick during the tournament
+ * window, so cache hits are the common case.
+ *
+ * @param tournamentId the FRC tournament ID whose capability snapshot to fetch
+ * @return a promise resolving to the full team-capability array
+ * @throws Error if the request fails or the server responds with a non-OK, non-304 status
+ */
+export async function getTeamCapability(
+  tournamentId: string,
+): Promise<TeamCapability[]> {
+  const { body } = await cacheFetch<TeamCapability[]>(
+    "/api/team-capability/" + encodeURIComponent(tournamentId),
+  );
   return body;
 }

--- a/app/common/sync/sync.ts
+++ b/app/common/sync/sync.ts
@@ -21,6 +21,7 @@ import {
   saveStrategyDrawing,
   deleteStrategyDrawing,
   parseDrawingStrokes,
+  getTeamCapability,
 } from "~/common/storage/rb.ts";
 import type { RBPlanWithDrawings } from "~/common/storage/rb.ts";
 import {
@@ -46,6 +47,7 @@ const ROBOT_ALERTS = "Robot Alerts";
 const ROBOT_ALERT_LIST = "Robot Alert List";
 const DASHBOARD_DATA = "Dashboard Data";
 const STRATEGY_PLANS = "Strategy Plans";
+const TEAM_CAPABILITY = "Team Capability";
 
 function log(msg: string): void {
   console.log(
@@ -171,6 +173,23 @@ const JOBS: SyncJob[] = [
     cadenceMs: 30_000,
     precondition: async () => hasSession() && (await windowActive()) && getNetworkHealth().alive === true,
     run: () => syncStrategyPlans(),
+    lastRunAt: 0,
+  },
+  {
+    // P1 Unit 6 — team capability snapshot. cacheFetch with If-None-Match keeps the network
+    // hit cheap (304 most ticks); the precondition idles the job outside the tournament
+    // window so a Tuesday tick is a no-op. Runs once per active tournament so the schedule
+    // page (Unit 7) and strategy page (Unit 8) can read by tournamentId offline.
+    id: "team-capability",
+    cadenceMs: 30_000,
+    precondition: async () => {
+      if (!hasSession()) return false;
+      if (getNetworkHealth().alive !== true) return false;
+      const tournaments = await repository.getTournamentList();
+      // Window-active AND at least one active tournament (i.e. a tournamentId is known).
+      return activeTournaments(tournaments).length > 0;
+    },
+    run: () => syncTeamCapability(),
     lastRunAt: 0,
   },
   {
@@ -835,6 +854,27 @@ export async function syncRobotAlertList() {
     await repository.putRobotAlerts(data);
   });
 }
+
+/**
+ * Fetch-then-persist the team-capability snapshot for every active tournament. One GET per
+ * active tournament; {@code cacheFetch} short-circuits to the stored ETag body on 304 so the
+ * steady-state cost is close to free. Results are written to the {@code teamCapability} store
+ * keyed by tournamentId — Units 7 and 8 read straight from IndexedDB.
+ */
+export async function syncTeamCapability() {
+  await runSync(TEAM_CAPABILITY, async () => {
+    const tournaments = await repository.getTournamentList();
+    const activeTournamentIds = activeTournaments(tournaments).map((t) => t.id);
+    for (const tid of activeTournamentIds) {
+      const rows = await getTeamCapability(tid);
+      await repository.putTeamCapability(tid, rows);
+    }
+  });
+}
+
+export const useTeamCapabilitySyncStatus = (): SyncStatus => {
+  return useSyncStatus(TEAM_CAPABILITY);
+};
 
 export async function updateRobotAlertUnsyncCount() {
   const data = await repository.getUnsynchronizedRobotAlerts();

--- a/app/components/MatchTeamsTable.tsx
+++ b/app/components/MatchTeamsTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { repository } from "~/common/storage/db.ts";
+import { getTeamCapability as fetchTeamCapability } from "~/common/storage/rb.ts";
 import type { TeamCapability } from "~/types/TeamCapability.ts";
 
 /**
@@ -126,7 +127,21 @@ function useTeamCapability(tournamentId: string): {
         }
       }
     };
+    // On-demand fetch: the JOBS sync only populates active tournaments, so post-season
+    // (or unwatched) tournaments start with an empty IndexedDB store. One-off fetch ensures
+    // the page has data to render; cacheFetch handles ETag re-use on subsequent mounts.
+    const syncIfEmpty = async () => {
+      try {
+        const existing = await repository.getTeamCapability(tournamentId);
+        if (existing.length > 0) return;
+        const rows = await fetchTeamCapability(tournamentId);
+        await repository.putTeamCapability(tournamentId, rows);
+      } catch (err) {
+        console.warn("On-demand team-capability fetch failed", err);
+      }
+    };
     load();
+    syncIfEmpty();
     const interval = setInterval(load, 1000);
     return () => {
       isMounted = false;

--- a/app/components/MatchTeamsTable.tsx
+++ b/app/components/MatchTeamsTable.tsx
@@ -1,0 +1,409 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { repository } from "~/common/storage/db.ts";
+import type { TeamCapability } from "~/types/TeamCapability.ts";
+
+/**
+ * Unit 8 — Team Capability Rankings P1.
+ *
+ * Renders a Match Teams input table ABOVE the strategy diagrams on the match
+ * strategy page. Six rows in a standard match (Red 1-3 / Blue 1-3), or 7-8
+ * rows in a 4-team playoff alliance.
+ *
+ * Behaviour:
+ * - Alliance-grouped: Red alliance rows first, then Blue alliance rows.
+ * - Alliance colour is a redundant CB-safe channel — an explicit "Red" / "Blue"
+ *   label column always appears, so screen readers and colour-blind users can
+ *   still distinguish alliance membership.
+ * - Within-alliance rank is computed client-side per numeric column using
+ *   standard competition ranking (1, 2, 2, 4). Rendered as
+ *   `<span className="schedule-team-rank">({rank})</span>` after the value.
+ * - **Rank suppression**:
+ *    1. If fewer than 2 non-null values in the alliance for the column, no rank.
+ *    2. If all non-null values are equal (spread = 0), no rank.
+ * - Missing numeric data: em dash, no rank; excluded from rank computation.
+ * - Withdrawn teams: strikethrough row (CSS `text-decoration: line-through`);
+ *   included inside their alliance group; excluded from rank computation.
+ * - Owner team (1310) row highlighted via the existing `rankings-row-owner`.
+ * - Row click navigates to `/report/summary/:teamNumber`.
+ * - No sort controls, no expand-collapse (6 rows, pre-grouped).
+ * - Staleness: `.banner-info` at the top of the card when any team's OPR or
+ *   EPA is stale.
+ * - Loading: skeleton row. Error: `.banner-warning` replacement.
+ *
+ * Columns (Coverage dropped vs. Unit 7 to save horizontal space):
+ *   Alliance | Team | Overall EPA | Auto EPA | Teleop EPA | Endgame EPA |
+ *   OPR | Auto Acc | Teleop Succ | Pickup Avg | Comments | Alerts
+ */
+
+export interface MatchTeamsTableProps {
+  tournamentId: string;
+  ownerTeam: number;
+  redTeams: number[];
+  blueTeams: number[];
+}
+
+type NumericKey =
+  | "epaTotal"
+  | "epaAuto"
+  | "epaTeleop"
+  | "epaEndgame"
+  | "opr"
+  | "autoAccuracy"
+  | "teleopSuccessRate"
+  | "pickupAverage"
+  | "quickCommentCount"
+  | "robotAlertCount";
+
+interface ColumnSpec {
+  key: NumericKey;
+  label: string;
+  format: (v: number | null) => string;
+}
+
+function fmtNumber(n: number | null, digits: number = 1): string {
+  if (n === null || n === undefined) return "—";
+  return n.toFixed(digits);
+}
+
+function fmtPercent(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  return `${(n * 100).toFixed(0)}%`;
+}
+
+function fmtInt(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  return String(n);
+}
+
+const COLUMNS: ColumnSpec[] = [
+  { key: "epaTotal", label: "Overall EPA", format: (v) => fmtNumber(v) },
+  { key: "epaAuto", label: "Auto EPA", format: (v) => fmtNumber(v) },
+  { key: "epaTeleop", label: "Teleop EPA", format: (v) => fmtNumber(v) },
+  { key: "epaEndgame", label: "Endgame EPA", format: (v) => fmtNumber(v) },
+  { key: "opr", label: "OPR", format: (v) => fmtNumber(v) },
+  { key: "autoAccuracy", label: "Auto Acc", format: (v) => fmtPercent(v) },
+  {
+    key: "teleopSuccessRate",
+    label: "Teleop Succ",
+    format: (v) => fmtPercent(v),
+  },
+  { key: "pickupAverage", label: "Pickup Avg", format: (v) => fmtNumber(v) },
+  { key: "quickCommentCount", label: "Comments", format: (v) => fmtInt(v) },
+  { key: "robotAlertCount", label: "Alerts", format: (v) => fmtInt(v) },
+];
+
+function readNumeric(row: TeamCapability, key: NumericKey): number | null {
+  const v = row[key];
+  if (v === null || v === undefined) return null;
+  return v;
+}
+
+function useTeamCapability(tournamentId: string): {
+  data: TeamCapability[];
+  loading: boolean;
+  error: string | null;
+} {
+  const [data, setData] = useState<TeamCapability[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const rows = await repository.getTeamCapability(tournamentId);
+        if (isMounted) {
+          setData(rows);
+          setError(null);
+          setLoading(false);
+        }
+      } catch (err) {
+        console.error("Failed to load team capability", err);
+        if (isMounted) {
+          setError("Couldn't load team capability");
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    const interval = setInterval(load, 1000);
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, [tournamentId]);
+
+  return { data, loading, error };
+}
+
+/**
+ * Compute standard competition rank (1, 2, 2, 4) for each row in `rows`,
+ * ranking descending by `value(row)`. Rows whose value is null are assigned
+ * rank=null. Withdrawn rows are also assigned rank=null (but still included
+ * in the returned map so the caller can key by team number).
+ *
+ * Returns a map keyed by teamNumber -> rank (or null).
+ *
+ * Suppression rules (applied here, returning null for all values in the
+ * alliance when either holds):
+ *   1. Fewer than 2 non-null, non-withdrawn values → no ranks.
+ *   2. Spread (max - min) across those values is 0 → no ranks.
+ */
+function computeAllianceRanks(
+  rows: TeamCapability[],
+  key: NumericKey,
+): Map<number, number | null> {
+  const result = new Map<number, number | null>();
+
+  // Gather the (teamNumber, value) pairs that participate in ranking.
+  const eligible: { teamNumber: number; value: number }[] = [];
+  for (const r of rows) {
+    if (r.withdrawn) {
+      result.set(r.teamNumber, null);
+      continue;
+    }
+    const v = readNumeric(r, key);
+    if (v === null) {
+      result.set(r.teamNumber, null);
+      continue;
+    }
+    eligible.push({ teamNumber: r.teamNumber, value: v });
+  }
+
+  // Suppression rule 1: fewer than 2 eligible values → no ranks at all.
+  if (eligible.length < 2) {
+    for (const e of eligible) result.set(e.teamNumber, null);
+    return result;
+  }
+
+  // Suppression rule 2: spread is 0 → no ranks.
+  let min = eligible[0].value;
+  let max = eligible[0].value;
+  for (const e of eligible) {
+    if (e.value < min) min = e.value;
+    if (e.value > max) max = e.value;
+  }
+  if (max - min === 0) {
+    for (const e of eligible) result.set(e.teamNumber, null);
+    return result;
+  }
+
+  // Standard competition ranking: sort desc, assign 1..n; ties share the
+  // lower rank and the next rank jumps past them (1, 2, 2, 4).
+  const sorted = eligible.slice().sort((a, b) => b.value - a.value);
+  let currentRank = 0;
+  let lastValue: number | null = null;
+  let lastRank = 0;
+  sorted.forEach((e, index) => {
+    currentRank = index + 1;
+    if (lastValue !== null && e.value === lastValue) {
+      result.set(e.teamNumber, lastRank);
+    } else {
+      result.set(e.teamNumber, currentRank);
+      lastRank = currentRank;
+      lastValue = e.value;
+    }
+  });
+  return result;
+}
+
+interface AllianceBlockData {
+  alliance: "red" | "blue";
+  rows: TeamCapability[];
+  ranks: Map<NumericKey, Map<number, number | null>>;
+}
+
+function buildAllianceBlock(
+  alliance: "red" | "blue",
+  teamNumbers: number[],
+  data: TeamCapability[],
+): AllianceBlockData {
+  const byTeam = new Map<number, TeamCapability>();
+  for (const r of data) byTeam.set(r.teamNumber, r);
+
+  // Preserve schedule slot order (R1..R4 / B1..B4). If a team is missing from
+  // the capability dataset, synthesise a row so the scout still sees the team
+  // number with em dashes for every column (no rank contribution).
+  const rows: TeamCapability[] = teamNumbers.map((tn) => {
+    const existing = byTeam.get(tn);
+    if (existing) return existing;
+    return {
+      teamNumber: tn,
+      teamName: null,
+      opr: null,
+      oprStale: false,
+      epaTotal: null,
+      epaAuto: null,
+      epaTeleop: null,
+      epaEndgame: null,
+      epaUnitless: null,
+      epaNorm: null,
+      epaStale: false,
+      autoAccuracy: null,
+      teleopSuccessRate: null,
+      pickupAverage: null,
+      quickCommentCount: 0,
+      robotAlertCount: 0,
+      robotAlertMaxSeverity: null,
+      scoutingCoverage: "none",
+      withdrawn: false,
+    };
+  });
+
+  const ranks = new Map<NumericKey, Map<number, number | null>>();
+  for (const col of COLUMNS) {
+    ranks.set(col.key, computeAllianceRanks(rows, col.key));
+  }
+  return { alliance, rows, ranks };
+}
+
+interface CellProps {
+  row: TeamCapability;
+  col: ColumnSpec;
+  rank: number | null;
+}
+
+function ValueCell({ row, col, rank }: CellProps) {
+  const raw = readNumeric(row, col.key);
+  const formatted = col.format(raw);
+  const showRank = rank !== null && raw !== null && !row.withdrawn;
+  return (
+    <td>
+      {formatted}
+      {showRank && (
+        <span className="schedule-team-rank">({rank})</span>
+      )}
+    </td>
+  );
+}
+
+export default function MatchTeamsTable({
+  tournamentId,
+  ownerTeam,
+  redTeams,
+  blueTeams,
+}: MatchTeamsTableProps) {
+  const { data, loading, error } = useTeamCapability(tournamentId);
+  const navigate = useNavigate();
+
+  const blocks = useMemo<AllianceBlockData[]>(() => {
+    return [
+      buildAllianceBlock("red", redTeams, data),
+      buildAllianceBlock("blue", blueTeams, data),
+    ];
+  }, [data, redTeams, blueTeams]);
+
+  const anyStale = useMemo(() => {
+    const relevant = new Set<number>([...redTeams, ...blueTeams]);
+    return data.some(
+      (r) => relevant.has(r.teamNumber) && (r.oprStale || r.epaStale),
+    );
+  }, [data, redTeams, blueTeams]);
+
+  const handleRowClick = (teamNumber: number) => {
+    navigate(`/report/summary/${teamNumber}`);
+  };
+
+  const totalColumnCount = 2 /* alliance + team */ + COLUMNS.length;
+
+  return (
+    <section className="card match-teams-card">
+      <h3>Match Teams</h3>
+      {anyStale && !loading && !error && (
+        <div className="banner banner-info">
+          (i) Team capability data may be stale — sync in progress.
+        </div>
+      )}
+      {error ? (
+        <div className="banner banner-warning">
+          Couldn't load team capability — try again in a moment.
+        </div>
+      ) : (
+        <>
+          <p className="schedule-rotate-hint">Rotate for more columns</p>
+          <div className="schedule-table-wrapper">
+            <table className="schedule-table match-teams-table">
+              <thead>
+                <tr>
+                  <th className="mt-col-alliance">Alliance</th>
+                  <th className="mt-col-team">Team</th>
+                  {COLUMNS.map((col) => (
+                    <th key={col.key}>{col.label}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {loading && data.length === 0 && (
+                  <tr>
+                    <td colSpan={totalColumnCount} className="mt-loading-cell">
+                      Loading match teams…
+                    </td>
+                  </tr>
+                )}
+                {!loading &&
+                  blocks.map((block) => {
+                    const allianceLabel =
+                      block.alliance === "red" ? "Red" : "Blue";
+                    const allianceRowClass =
+                      block.alliance === "red"
+                        ? "match-teams-row-red"
+                        : "match-teams-row-blue";
+                    return block.rows.map((row, indexInAlliance) => {
+                      const isOwner = row.teamNumber === ownerTeam;
+                      const isFirstInAlliance = indexInAlliance === 0;
+                      const classNames = [
+                        allianceRowClass,
+                        isFirstInAlliance
+                          ? "match-teams-alliance-first"
+                          : "",
+                        isOwner ? "rankings-row-owner" : "",
+                        row.withdrawn ? "match-teams-row-withdrawn" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ");
+                      return (
+                        <tr
+                          key={`${block.alliance}-${row.teamNumber}`}
+                          className={classNames}
+                          onClick={() => handleRowClick(row.teamNumber)}
+                          style={{ cursor: "pointer" }}
+                        >
+                          <td className="mt-col-alliance">{allianceLabel}</td>
+                          <td className="mt-col-team">
+                            <span className="mt-team-number">
+                              {row.teamNumber}
+                            </span>
+                            {row.teamName && (
+                              <span className="mt-team-name">
+                                {" "}
+                                {row.teamName}
+                              </span>
+                            )}
+                          </td>
+                          {COLUMNS.map((col) => {
+                            const rankMap = block.ranks.get(col.key);
+                            const rank = rankMap
+                              ? rankMap.get(row.teamNumber) ?? null
+                              : null;
+                            return (
+                              <ValueCell
+                                key={col.key}
+                                row={row}
+                                col={col}
+                                rank={rank}
+                              />
+                            );
+                          })}
+                        </tr>
+                      );
+                    });
+                  })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/components/TournamentTeamsCard.tsx
+++ b/app/components/TournamentTeamsCard.tsx
@@ -302,6 +302,9 @@ export default function TournamentTeamsCard({
             <table className="schedule-table tournament-teams-table">
               <thead>
                 <tr>
+                  <th scope="col" className="tt-col-rank">
+                    Rank
+                  </th>
                   <SortHeader
                     label="Team"
                     sortKey="team"
@@ -390,7 +393,7 @@ export default function TournamentTeamsCard({
                 {loading && data.length === 0 && (
                   <tr>
                     <td
-                      colSpan={isNarrow ? 3 : 12}
+                      colSpan={isNarrow ? 4 : 13}
                       className="tt-loading-cell"
                     >
                       Loading team capability…
@@ -400,14 +403,14 @@ export default function TournamentTeamsCard({
                 {!loading && data.length === 0 && (
                   <tr>
                     <td
-                      colSpan={isNarrow ? 3 : 12}
+                      colSpan={isNarrow ? 4 : 13}
                       className="tt-empty-cell"
                     >
                       No team capability data yet.
                     </td>
                   </tr>
                 )}
-                {sortedRows.map((row) => {
+                {sortedRows.map((row, index) => {
                   const isOwner = row.teamNumber === ownerTeam;
                   const classNames = [
                     isOwner ? "rankings-row-owner" : "",
@@ -422,6 +425,7 @@ export default function TournamentTeamsCard({
                       onClick={() => handleRowClick(row.teamNumber)}
                       style={{ cursor: "pointer" }}
                     >
+                      <td className="tt-col-rank">{index + 1}</td>
                       <td className="tt-col-team">
                         <span className="tt-team-number">{row.teamNumber}</span>
                         {row.teamName && (

--- a/app/components/TournamentTeamsCard.tsx
+++ b/app/components/TournamentTeamsCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { repository } from "~/common/storage/db.ts";
+import { getTeamCapability as fetchTeamCapability } from "~/common/storage/rb.ts";
 import type { TeamCapability } from "~/types/TeamCapability.ts";
 
 /**
@@ -79,7 +80,21 @@ function useTeamCapability(tournamentId: string): {
         }
       }
     };
+    // On-demand fetch: the JOBS sync only populates active tournaments, so post-season
+    // (or unwatched) tournaments start with an empty IndexedDB store. One-off fetch ensures
+    // the page has data to render; cacheFetch handles ETag re-use on subsequent mounts.
+    const syncIfEmpty = async () => {
+      try {
+        const existing = await repository.getTeamCapability(tournamentId);
+        if (existing.length > 0) return;
+        const rows = await fetchTeamCapability(tournamentId);
+        await repository.putTeamCapability(tournamentId, rows);
+      } catch (err) {
+        console.warn("On-demand team-capability fetch failed", err);
+      }
+    };
     load();
+    syncIfEmpty();
     const interval = setInterval(load, 1000);
     return () => {
       isMounted = false;

--- a/app/components/TournamentTeamsCard.tsx
+++ b/app/components/TournamentTeamsCard.tsx
@@ -1,0 +1,456 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { repository } from "~/common/storage/db.ts";
+import type { TeamCapability } from "~/types/TeamCapability.ts";
+
+/**
+ * Unit 7 — Team Capability Rankings P1.
+ *
+ * Renders a sortable, owner-highlighted capability table card below the rest of the
+ * team-schedule page stack. Reads from IndexedDB (populated by Unit 6's JOBS sync).
+ *
+ * Behaviour:
+ * - Columns (landscape / tablet / desktop): Team (# + Name) | Overall EPA | Auto EPA |
+ *   Teleop EPA | Endgame EPA | OPR | Auto Accuracy | Teleop Success | Pickup Avg |
+ *   Comments | Alerts | Coverage.
+ * - Portrait-iPhone: narrow 3-column view (Team | Overall EPA | OPR).
+ * - Default sort: OPR desc. Nulls always last. Withdrawn rows always last.
+ * - Click header to sort; click again to flip direction.
+ * - Owner row highlighted with the existing `rankings-row-owner` class.
+ * - Row click navigates to the team-summary page (/report/summary/:teamId).
+ * - Missing numeric data renders as an em dash.
+ * - Staleness banner (top of card) when any row has `oprStale` or `epaStale === true`.
+ */
+
+type SortKey =
+  | "team"
+  | "epaTotal"
+  | "epaAuto"
+  | "epaTeleop"
+  | "epaEndgame"
+  | "opr"
+  | "autoAccuracy"
+  | "teleopSuccessRate"
+  | "pickupAverage"
+  | "quickCommentCount"
+  | "robotAlertCount"
+  | "scoutingCoverage";
+
+type SortDirection = "asc" | "desc";
+
+interface SortState {
+  key: SortKey;
+  direction: SortDirection;
+}
+
+const DEFAULT_SORT: SortState = { key: "opr", direction: "desc" };
+
+// Coverage ordering: full > thin > none.
+const COVERAGE_ORDER: Record<TeamCapability["scoutingCoverage"], number> = {
+  full: 3,
+  thin: 2,
+  none: 1,
+};
+
+function useTeamCapability(tournamentId: string): {
+  data: TeamCapability[];
+  loading: boolean;
+  error: string | null;
+} {
+  const [data, setData] = useState<TeamCapability[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const rows = await repository.getTeamCapability(tournamentId);
+        if (isMounted) {
+          setData(rows);
+          setError(null);
+          setLoading(false);
+        }
+      } catch (err) {
+        console.error("Failed to load team capability", err);
+        if (isMounted) {
+          setError("Couldn't load team capability");
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    const interval = setInterval(load, 1000);
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, [tournamentId]);
+
+  return { data, loading, error };
+}
+
+function useIsNarrow(): boolean {
+  const [isNarrow, setIsNarrow] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(max-width: 480px) and (orientation: portrait)")
+      .matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(
+      "(max-width: 480px) and (orientation: portrait)",
+    );
+    const onChange = (e: MediaQueryListEvent) => setIsNarrow(e.matches);
+    if (mql.addEventListener) mql.addEventListener("change", onChange);
+    else mql.addListener(onChange);
+    return () => {
+      if (mql.removeEventListener) mql.removeEventListener("change", onChange);
+      else mql.removeListener(onChange);
+    };
+  }, []);
+  return isNarrow;
+}
+
+function getSortValue(row: TeamCapability, key: SortKey): number | string | null {
+  switch (key) {
+    case "team":
+      return row.teamNumber;
+    case "epaTotal":
+      return row.epaTotal;
+    case "epaAuto":
+      return row.epaAuto;
+    case "epaTeleop":
+      return row.epaTeleop;
+    case "epaEndgame":
+      return row.epaEndgame;
+    case "opr":
+      return row.opr;
+    case "autoAccuracy":
+      return row.autoAccuracy;
+    case "teleopSuccessRate":
+      return row.teleopSuccessRate;
+    case "pickupAverage":
+      return row.pickupAverage;
+    case "quickCommentCount":
+      return row.quickCommentCount;
+    case "robotAlertCount":
+      return row.robotAlertCount;
+    case "scoutingCoverage":
+      return COVERAGE_ORDER[row.scoutingCoverage];
+  }
+}
+
+function sortRows(rows: TeamCapability[], sort: SortState): TeamCapability[] {
+  const copy = rows.slice();
+  const dirMult = sort.direction === "asc" ? 1 : -1;
+  copy.sort((a, b) => {
+    // Withdrawn rows always sort last regardless of direction.
+    if (a.withdrawn !== b.withdrawn) return a.withdrawn ? 1 : -1;
+
+    const av = getSortValue(a, sort.key);
+    const bv = getSortValue(b, sort.key);
+
+    // Nulls always sort last regardless of direction.
+    const aNull = av === null || av === undefined;
+    const bNull = bv === null || bv === undefined;
+    if (aNull && bNull) {
+      // Stable tiebreak on team number (ascending).
+      return a.teamNumber - b.teamNumber;
+    }
+    if (aNull) return 1;
+    if (bNull) return -1;
+
+    if (typeof av === "number" && typeof bv === "number") {
+      if (av === bv) return a.teamNumber - b.teamNumber;
+      return (av - bv) * dirMult;
+    }
+    const cmp = String(av).localeCompare(String(bv));
+    if (cmp === 0) return a.teamNumber - b.teamNumber;
+    return cmp * dirMult;
+  });
+  return copy;
+}
+
+function fmtNumber(n: number | null, digits: number = 1): string {
+  if (n === null || n === undefined) return "—";
+  return n.toFixed(digits);
+}
+
+function fmtPercent(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  return `${(n * 100).toFixed(0)}%`;
+}
+
+function fmtInt(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  return String(n);
+}
+
+function CoveragePill({
+  coverage,
+}: {
+  coverage: TeamCapability["scoutingCoverage"];
+}) {
+  const label =
+    coverage === "full" ? "Full" : coverage === "thin" ? "Thin" : "None";
+  const className = `badge-scouting-${coverage}`;
+  return <span className={className}>{label}</span>;
+}
+
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  current: SortState;
+  onSort: (key: SortKey) => void;
+  className?: string;
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  current,
+  onSort,
+  className,
+}: SortHeaderProps) {
+  const active = current.key === sortKey;
+  const ariaSort = active
+    ? current.direction === "asc"
+      ? "ascending"
+      : "descending"
+    : "none";
+  const indicator = active ? (current.direction === "asc" ? " ▲" : " ▼") : "";
+  return (
+    <th
+      className={className}
+      aria-sort={ariaSort}
+      onClick={() => onSort(sortKey)}
+      style={{ cursor: "pointer", userSelect: "none" }}
+    >
+      {label}
+      {indicator}
+    </th>
+  );
+}
+
+export interface TournamentTeamsCardProps {
+  tournamentId: string;
+  ownerTeam: number;
+}
+
+export default function TournamentTeamsCard({
+  tournamentId,
+  ownerTeam,
+}: TournamentTeamsCardProps) {
+  const { data, loading, error } = useTeamCapability(tournamentId);
+  const navigate = useNavigate();
+  const isNarrow = useIsNarrow();
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+
+  const sortedRows = useMemo(() => sortRows(data, sort), [data, sort]);
+  const anyStale = useMemo(
+    () => data.some((r) => r.oprStale || r.epaStale),
+    [data],
+  );
+
+  const handleSort = (key: SortKey) => {
+    setSort((prev) => {
+      if (prev.key === key) {
+        return { key, direction: prev.direction === "asc" ? "desc" : "asc" };
+      }
+      // When switching to a new column, default to descending for numeric cols
+      // (higher is better); ascending for team (by number).
+      return { key, direction: key === "team" ? "asc" : "desc" };
+    });
+  };
+
+  const handleRowClick = (teamNumber: number) => {
+    navigate(`/report/summary/${teamNumber}`);
+  };
+
+  return (
+    <section className="card tournament-teams-card">
+      <h3>Tournament Teams</h3>
+      {anyStale && !loading && !error && (
+        <div className="banner banner-info">
+          (i) Team capability data may be stale — sync in progress.
+        </div>
+      )}
+      {error ? (
+        <div className="banner banner-warning">
+          Couldn't load team capability — try again in a moment.
+        </div>
+      ) : (
+        <>
+          <p className="schedule-rotate-hint">Rotate for more columns</p>
+          <div className="schedule-table-wrapper">
+            <table className="schedule-table tournament-teams-table">
+              <thead>
+                <tr>
+                  <SortHeader
+                    label="Team"
+                    sortKey="team"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-team"
+                  />
+                  <SortHeader
+                    label="Overall EPA"
+                    sortKey="epaTotal"
+                    current={sort}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    label="Auto EPA"
+                    sortKey="epaAuto"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Teleop EPA"
+                    sortKey="epaTeleop"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Endgame EPA"
+                    sortKey="epaEndgame"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="OPR"
+                    sortKey="opr"
+                    current={sort}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    label="Auto Acc"
+                    sortKey="autoAccuracy"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Teleop Succ"
+                    sortKey="teleopSuccessRate"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Pickup Avg"
+                    sortKey="pickupAverage"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Comments"
+                    sortKey="quickCommentCount"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Alerts"
+                    sortKey="robotAlertCount"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                  <SortHeader
+                    label="Coverage"
+                    sortKey="scoutingCoverage"
+                    current={sort}
+                    onSort={handleSort}
+                    className="tt-col-wide"
+                  />
+                </tr>
+              </thead>
+              <tbody>
+                {loading && data.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={isNarrow ? 3 : 12}
+                      className="tt-loading-cell"
+                    >
+                      Loading team capability…
+                    </td>
+                  </tr>
+                )}
+                {!loading && data.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={isNarrow ? 3 : 12}
+                      className="tt-empty-cell"
+                    >
+                      No team capability data yet.
+                    </td>
+                  </tr>
+                )}
+                {sortedRows.map((row) => {
+                  const isOwner = row.teamNumber === ownerTeam;
+                  const classNames = [
+                    isOwner ? "rankings-row-owner" : "",
+                    row.withdrawn ? "tournament-teams-row-withdrawn" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ");
+                  return (
+                    <tr
+                      key={row.teamNumber}
+                      className={classNames}
+                      onClick={() => handleRowClick(row.teamNumber)}
+                      style={{ cursor: "pointer" }}
+                    >
+                      <td className="tt-col-team">
+                        <span className="tt-team-number">{row.teamNumber}</span>
+                        {row.teamName && (
+                          <span className="tt-team-name">
+                            {" "}
+                            {row.teamName}
+                          </span>
+                        )}
+                      </td>
+                      <td>{fmtNumber(row.epaTotal)}</td>
+                      <td className="tt-col-wide">{fmtNumber(row.epaAuto)}</td>
+                      <td className="tt-col-wide">
+                        {fmtNumber(row.epaTeleop)}
+                      </td>
+                      <td className="tt-col-wide">
+                        {fmtNumber(row.epaEndgame)}
+                      </td>
+                      <td>{fmtNumber(row.opr)}</td>
+                      <td className="tt-col-wide">
+                        {fmtPercent(row.autoAccuracy)}
+                      </td>
+                      <td className="tt-col-wide">
+                        {fmtPercent(row.teleopSuccessRate)}
+                      </td>
+                      <td className="tt-col-wide">
+                        {fmtNumber(row.pickupAverage)}
+                      </td>
+                      <td className="tt-col-wide">
+                        {fmtInt(row.quickCommentCount)}
+                      </td>
+                      <td className="tt-col-wide">
+                        {fmtInt(row.robotAlertCount)}
+                      </td>
+                      <td className="tt-col-wide">
+                        <CoveragePill coverage={row.scoutingCoverage} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/routes/report/team-schedule-page.tsx
+++ b/app/routes/report/team-schedule-page.tsx
@@ -20,6 +20,7 @@ import {
   type ResolvedMatch,
 } from "~/common/bracket.ts";
 import BracketSvg from "~/common/BracketSvg.tsx";
+import TournamentTeamsCard from "~/components/TournamentTeamsCard.tsx";
 import type { RBTournament } from "~/types/RBTournament.ts";
 import type { NexusQueueStatus } from "~/types/NexusQueueStatus.ts";
 import type {
@@ -958,6 +959,10 @@ const TeamScheduleContent = ({ autoSelect = false }: { autoSelect?: boolean }) =
       )}
       <RankingsTable
         rankings={schedule.rankings}
+        ownerTeam={schedule.teamNumber}
+      />
+      <TournamentTeamsCard
+        tournamentId={schedule.tournamentId}
         ownerTeam={schedule.teamNumber}
       />
       {queueStatus && queueStatus.teamStatus && (

--- a/app/routes/strategy/strategy-plan-page.tsx
+++ b/app/routes/strategy/strategy-plan-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { NavLink, useParams } from "react-router";
 import RequireRole from "~/common/auth/RequireRole.tsx";
+import MatchTeamsTable from "~/components/MatchTeamsTable.tsx";
 import {
   repository,
   strategyPlanLocalKey,
@@ -206,6 +207,42 @@ function teamNumbersForMatch(
   };
 }
 
+/**
+ * Returns the teams in the match grouped by alliance, including slot 4 when
+ * non-zero (4-team playoff alliances + surrogates). Slot 4 is included for
+ * red and blue independently — a qualification match returns 3/3, a playoff
+ * alliance selection may return 4/4 or 3/4.
+ *
+ * Unlike {@link teamNumbersForMatch}, this helper flattens to alliance-level
+ * lists so match-surface components (Match Teams table) can group without
+ * owning RobotSlot mapping logic.
+ */
+function matchTeamsByAlliance(
+  schedule: RBScheduleRecord[],
+  tournamentId: string,
+  level: string,
+  matchNumber: number,
+): { red: number[]; blue: number[] } {
+  const m = schedule.find(
+    (r) =>
+      r.tournamentId === tournamentId &&
+      r.level === level &&
+      r.match === matchNumber,
+  );
+  if (!m) return { red: [], blue: [] };
+  const red: number[] = [];
+  const blue: number[] = [];
+  if (m.red1) red.push(m.red1);
+  if (m.red2) red.push(m.red2);
+  if (m.red3) red.push(m.red3);
+  if (m.red4) red.push(m.red4);
+  if (m.blue1) blue.push(m.blue1);
+  if (m.blue2) blue.push(m.blue2);
+  if (m.blue3) blue.push(m.blue3);
+  if (m.blue4) blue.push(m.blue4);
+  return { red, blue };
+}
+
 /** Owner team — Team 1310. Determines which alliance goes at the bottom of
  *  the rotated field diagram. (If 1310 isn't in the match, rotation falls
  *  back to source orientation.) */
@@ -272,6 +309,10 @@ const StrategyPlanPageInner = (props: {
   const { list: schedule } = useMatchSchedule();
   const teamNumbers = useMemo(
     () => teamNumbersForMatch(schedule, tournamentId, matchLevel, matchNumber),
+    [schedule, tournamentId, matchLevel, matchNumber],
+  );
+  const matchAllianceTeams = useMemo(
+    () => matchTeamsByAlliance(schedule, tournamentId, matchLevel, matchNumber),
     [schedule, tournamentId, matchLevel, matchNumber],
   );
   const rotation = useMemo<CanvasRotation>(
@@ -890,6 +931,17 @@ const StrategyPlanPageInner = (props: {
           )}
         </p>
       </div>
+
+      {matchLevel !== "Practice" &&
+        (matchAllianceTeams.red.length > 0 ||
+          matchAllianceTeams.blue.length > 0) && (
+          <MatchTeamsTable
+            tournamentId={tournamentId}
+            ownerTeam={OWNER_TEAM_NUMBER}
+            redTeams={matchAllianceTeams.red}
+            blueTeams={matchAllianceTeams.blue}
+          />
+        )}
 
       <div
         className={

--- a/app/types/TeamCapability.ts
+++ b/app/types/TeamCapability.ts
@@ -1,0 +1,37 @@
+/**
+ * Wire-level shape of one team's capability row, mirroring the backend
+ * {@code TeamCapabilityResponse} record 1:1. Combines TBA OPR, Statbotics EPA, and RavenBrain
+ * scouting aggregates into a single structure with server-computed staleness flags, coverage
+ * classification, and withdrawn detection.
+ *
+ * <p>Nullable numerics are modelled as {@code number | null} (not {@code number | undefined}) to
+ * match the Jackson serialization emitted by Micronaut Serde for {@code @Nullable Double} fields.
+ *
+ * <ul>
+ *   <li>{@code oprStale} — true when the backing OPR row is missing or last fetch failed.
+ *   <li>{@code epaStale} — true when the backing Statbotics row is missing or last fetch failed.
+ *   <li>{@code scoutingCoverage} — {@code "full"}, {@code "thin"}, or {@code "none"}.
+ *   <li>{@code withdrawn} — team appears in roster but absent from the latest Statbotics sync.
+ * </ul>
+ */
+export interface TeamCapability {
+  teamNumber: number;
+  teamName: string | null;
+  opr: number | null;
+  oprStale: boolean;
+  epaTotal: number | null;
+  epaAuto: number | null;
+  epaTeleop: number | null;
+  epaEndgame: number | null;
+  epaUnitless: number | null;
+  epaNorm: number | null;
+  epaStale: boolean;
+  autoAccuracy: number | null;
+  teleopSuccessRate: number | null;
+  pickupAverage: number | null;
+  quickCommentCount: number;
+  robotAlertCount: number;
+  robotAlertMaxSeverity: string | null;
+  scoutingCoverage: "full" | "thin" | "none";
+  withdrawn: boolean;
+}

--- a/docs/team-capability-p1.md
+++ b/docs/team-capability-p1.md
@@ -1,0 +1,122 @@
+---
+title: "feat: Team Capability Rankings (P1)"
+type: feat
+status: active
+date: 2026-04-19
+---
+
+# Team Capability Rankings (P1)
+
+**Companion to:** [`docs/plans/2026-04-19-002-feat-team-capability-rankings-p1-plan.md`](plans/2026-04-19-002-feat-team-capability-rankings-p1-plan.md). The plan is the full decision record; this is the two-page skim for anyone landing on the code cold.
+
+## Overview
+
+P1 fuses three data sources into a single per-tournament capability view and renders it on the two pages strat reaches for most during an event. A **Tournament Teams card** at the bottom of the team-schedule page lists every team at the tournament (sortable, default OPR desc, click-through to team-summary). A **Match Teams table** at the top of the strategy page lists only the 6–8 teams in the current match, grouped by alliance, with within-alliance ranks in parentheses next to each numeric column. Both read from one new endpoint (`GET /api/team-capability/{tournamentId}`) that returns OPR (from TBA), per-phase EPA (from Statbotics), and scouting aggregates (from our own event-log / quick-comment / robot-alert surfaces). Consumers: strat team for pick-list reference during alliance selection and pre-match sizing; expanded visibility to DRIVE_TEAM on the Match Teams table.
+
+## Data sources
+
+- **TBA OPR** — Statbotics does not expose OPR and FRC exposes rankings only, so OPR comes from TBA's `/event/{key}/oprs`. Extends the existing `tbaapi` package with one new client method, one new model, and a new `RB_TBA_EVENT_OPRS` table (composite PK on `(tba_event_key, team_number)`). The existing TBA scheduled sync gains one additional call per active tournament.
+- **Statbotics EPA with per-phase breakdown** — new `ca.team1310.ravenbrain.statboticsapi` package mirroring `tbaapi` exactly (`fetch` / `service` / `model` sub-packages). Statbotics is unauthenticated and exposes no conditional-request headers, so the caching client is **TTL-only** (no ETag / Last-Modified). Batch endpoint `/v3/team_events?event={key}&limit=1000` returns all ~80 teams for an event in a single call. Flat columns for the stable fields (`epa_total`, `epa_auto`, `epa_teleop`, `epa_endgame`, `epa_unitless`, `epa_norm`) plus a `breakdown_json` TEXT column for season-specific drill-down. Identified via `User-Agent: StratApp/<version> (+https://raveneye.team1310.ca)` per Statbotics' informal "please be nice" posture.
+- **Scouting aggregates** — existing services, accessed in bulk. New `TournamentAggregatesService` batches the work currently done one-team-at-a-time by `CustomTournamentStatsService` into a single call that returns per-team rows for every team at a tournament. Pulls scoring averages (auto accuracy, teleop success rate, pickup average) from the event log and summary counts (quick-comment count, robot-alert count + max severity) from the admin surfaces.
+
+## Component graph
+
+```
+┌────────────────────────────┐  1h    ┌────────────────────────────┐
+│ StatboticsTeamEventSync    │───────▶│ Statbotics v3 REST         │
+│ (scope: watched ∪ team-    │        │ GET /v3/team_events?event= │
+│  owner ∩ active-window,    │        │   {key}&limit=1000         │
+│  non-blank tba_event_key)  │        └────────────────────────────┘
+└─────────────┬──────────────┘
+              │ writes only
+              ▼
+┌────────────────────────────┐
+│ RB_STATBOTICS_TEAM_EVENT   │
+│ epa_* columns +            │
+│ breakdown_json (8 KB cap)  │
+└─────────────┬──────────────┘
+              │                ┌────────────────────────────┐  1h    ┌──────────────────┐
+              │                │ TbaEventSyncService (P0)   │───────▶│ TBA v3 REST      │
+              │                │  + OPR call (new in P1)    │        │ /event/{k}/oprs  │
+              │                └─────────────┬──────────────┘        └──────────────────┘
+              │                              │ writes only
+              │                              ▼
+              │                ┌────────────────────────────┐
+              │                │ RB_TBA_EVENT_OPRS          │
+              │                └─────────────┬──────────────┘
+              │                              │
+              │  ┌───────────────────────────┘
+              │  │
+              ▼  ▼
+┌───────────────────────────────────────────────────────────────┐
+│ TeamCapabilityEnricher.enrich(tournamentId)  [pure read]      │
+│   teams         = TeamTournamentService.findTeamsFor(id)      │
+│   opr_by_team   = TbaEventOprsRepo.findByTbaEventKey(k)       │
+│   sbx_by_team   = StatboticsTeamEventRepo.findByEventKey(k)   │
+│   scout_by_team = TournamentAggregatesService.getAll(id)      │
+│   → join in memory, compute staleness + coverage flags        │
+└─────────────────────────────────┬─────────────────────────────┘
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│ GET /api/team-capability/{tournamentId}   IS_AUTHENTICATED    │
+│   backed by TeamCapabilityCache (invalidate on event-log      │
+│   writes, Statbotics / OPR sync completions)                  │
+└─────────────────────────────────┬─────────────────────────────┘
+                                  │ cacheFetch (If-None-Match)
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│ IndexedDB teamCapability store  (cleared by clearDataCaches)  │
+└─────────────────────────────────┬─────────────────────────────┘
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│ RavenEye                                                      │
+│   /report/schedule/:tournamentId  → TournamentTeamsCard       │
+│   /strategy/:id/:level/:match     → MatchTeamsTable           │
+│                                     (6–8 teams, within-       │
+│                                     alliance ranks, CB-safe)  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Response shape
+
+`GET /api/team-capability/{tournamentId}` returns a list of `TeamCapabilityResponse`, one per team at the tournament:
+
+- **Identity** — `teamNumber`, `teamName`, `withdrawn` (true when team is in `RB_TEAM_TOURNAMENT` but absent from the latest Statbotics roster sync).
+- **TBA** — `opr?`, `oprStale` (server-computed from `last_status` / `last_sync`).
+- **Statbotics** — `epaTotal?`, `epaAuto?`, `epaTeleop?`, `epaEndgame?`, `epaUnitless?`, `epaNorm?`, `epaStale` (same posture). `epaUnitless` / `epaNorm` included for cross-year cases but not rendered in v1.
+- **Scouting** — `autoAccuracy?`, `teleopSuccessRate?`, `pickupAverage?`, `quickCommentCount`, `robotAlertCount`, `robotAlertMaxSeverity?`, `scoutingCoverage` (`"full"` / `"thin"` / `"none"`).
+
+Missing data surfaces as `null` and renders as `—` in the UI with no rank. Staleness booleans are computed server-side; the client never derives them from timestamps.
+
+## Key decisions
+
+- **OPR from TBA, not Statbotics** — Statbotics has no OPR; FRC exposes rankings only. TBA plumbing is already in place from P0.
+- **TTL-only Statbotics caching** — no ETag / Last-Modified observed. The cache-response table keeps those columns for structural parity with `RB_TBA_RESPONSES` but they stay NULL for every row.
+- **5-minute force-sync guard** — `POST /api/statbotics-sync` rejects with 429 if a successful sync completed within the last five minutes. Hard-coded (no admin knob). Cheap protection against SUPERUSER-token spam against Statbotics' informal posture.
+- **8 KB `breakdown_json` cap** — sync rejects responses where the blob exceeds the cap (`last_status = 422`, prior row preserved). Well above any real breakdown size in practice; guards against upstream expansion or a malicious proxy.
+- **Event-log-only coverage classifier** — `scoutingCoverage` is `"full"` when all scoring averages are non-null, `"none"` when all are null and counts are zero, `"thin"` otherwise. Comment count is its own column and does **not** participate in the coverage classification — quantitative and qualitative coverage are different signals.
+- **Within-alliance ranks with suppression** — the Match Teams table ranks 1–3 (or 1–4 for 4-team alliances) **within each alliance**, not 1–6 across both. Computed client-side. When an alliance has only one non-null value in a column, render without rank ("(1)" would imply best-of-three). When all alliance values in a column are equal, render all values without rank.
+- **Withdrawn teams render strikethrough** — and sort last regardless of column direction. Detected by roster-vs-Statbotics diff; Statbotics drops withdrawn teams mid-event while TBA keeps them.
+- **IDOR accepted at `IS_AUTHENTICATED`** — `GET /api/team-capability/{tournamentId}` is accessible to any authenticated user regardless of tournament ownership. Aggregate scouting signals for opposing teams are low-sensitivity for a student-team context; tournament scoping would add code without meaningful risk reduction. Recorded to prevent silent drift on revisit.
+- **OPR-desc as arbitrary default sort** — strat uses both OPR and EPA. The default is a placeholder; first-tournament feedback revisits.
+- **Disjoint writers invariant** — `statboticsapi` writes only to `RB_STATBOTICS_*`, `tbaapi` OPR writes only to `RB_TBA_EVENT_OPRS`, scouting surfaces are unchanged. The enricher is pure read. No shared write surface between external sync and admin CRUD.
+
+## Operational notes
+
+- **`POST /api/statbotics-sync`** — `ROLE_SUPERUSER`. Returns 202 on acquire, 409 if another sync is in flight (`AtomicBoolean` gate), 429 if the last successful sync was within 5 minutes. Force-sync path for tournament-day refreshes; no admin UI button.
+- **`POST /api/tba-sync`** — existing P0 endpoint, unchanged response shape. Extended to additionally pull OPR under the same gate; OPR failure in a given tournament does not abort event-level sync.
+- **Per-sync summary logs** — `"Statbotics sync: X tournaments, Y team-event rows written, Z failures"` and `"TBA OPR sync: X tournaments, Y team rows written, Z failures"`. Supports the adoption-measure-then-cut success criterion.
+- **Rollout is safe to ship dark** — a tournament without a `tba_event_key` simply has no external sync and renders the card with scouting-only rows and `—` in OPR / EPA cells. Enabling per-tournament is an admin action (set `tba_event_key` via the P0 admin UI).
+- **Deployment** — release via `/kd-pr`. RavenBrain PR merges first (V35 migration + packages + endpoint) and RavenEye PR follows (types + sync registration + components + page insertions). Off-season merge-order breakage is tolerable; enforce RB-before-RE during tournament season.
+
+## What's not in P1
+
+- **No admin force-sync UI** — curl-only, mirroring P0. Add a button if tournament-day lag becomes a real pain.
+- **No `cacheFetch` migration** — the network-communication-refinement has fully landed on `main` and P1 adopts `cacheFetch`, the `JOBS` array sync scheduler, `tournamentWindow` helpers, and `clearDataCaches` directly.
+- **No admin rate-limiting knob** — the 5-minute force-sync guard is a hard-coded constant. Making it configurable is deferred.
+- **No season-wide EPA fetch** — `/v3/team_years` batching is P2 (season-arc visualization).
+- **No partner-fit / synergy scoring** — P3 (R13). Per-phase EPA columns stay flat; coupling to `strategyarea` waits until weighted phase aggregation has a real consumer.
+
+## Operational bookmark — thundering-herd watch
+
+Event-log writes invalidate the `TeamCapabilityCache` so scouting aggregates reflect recent in-match entries. During active matches, 8–12 tablets running the 30-second `JOBS` cadence can hit the cold cache within the same sync tick. Report pages are consulted primarily between matches rather than during them, so the expected load is low and no rate-limiting or debouncing is implemented for v1. Revisit if slow `/api/team-capability` responses, request pile-ups, or timeouts during sync cycles appear in logs at a real tournament — natural remediations include a short post-invalidation debounce on the cache key or a stale-while-revalidate serve on the enricher. No code change until we see the signal.


### PR DESCRIPTION
- **feat(capability): frontend data layer (Unit 6)**
- **feat(capability): Tournament Teams card (Unit 7)**
- **feat(capability): Match Teams table on strategy page (Unit 8)**
- **docs(capability): team-capability-p1 design doc (Unit 9)**
- **fix(capability): on-demand fetch when IndexedDB is empty**
- **fix(db): handle IndexedDB upgrade-blocked and cross-tab version change**
- **feat(capability): add Rank column to Tournament Teams card**
